### PR TITLE
Attach labels to input elements by id

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,34 +2,3 @@
 #+PARENT: ../../doc/webdev/index.org
 
 A library of libraries and widgets for ~Incr_dom~ applications.
-
-For the moment, most of the libraries contained here are about
-efficient rendering of tabular data, in particular supporting /partial
-rendering/, i.e., only rendering a subset of the widgets that are
-logically in the view, depending on what is expected to be visible to
-the end user.
-
-* Mesa
-
-  Mesa provides an /easy/ way of creating functional web
-  tables. The user supplies a ~row~ type and "actions" to be run on
-  those ~rows~ (along with some other functionality) and the user gets
-  back a table capable of:
-
-  - Partial rendering
-  - Navigating the table with the arrow keys and the mouse
-  - Sorting the table on a column
-  - Editing the table-cells' values and communicating those changes
-    back to a server
-  - Searching the table for a row
-
-  (see =./src/mesa_intf.ml= from more details)
-
-* Keybard\_event\_handler, Variable\_keyboard\_event\_hander, Help\_text and Grouped\_help\_text
-
-  The =Keyboard_event_handler= and =Help_text= modules provide a way of
-  creating a keyboard event handler and generating help text for it.
-  =Variable_keyboard_event_handler= provides some additional
-  functionality on top of =Keyboard_event_handler=, and similarly
-  =Grouped_help_text= provides some additional functionality on top of
-  =Help_text=.

--- a/example/username_gen/app.ml
+++ b/example/username_gen/app.ml
@@ -2,12 +2,9 @@ open Core_kernel
 open Incr_dom
 open Incr.Let_syntax
 open Incr_dom_widgets
-
 open Vdom
-
 open! Int.Replace_polymorphic_compare
-
-module User_id = Unique_id.Int()
+module User_id = Unique_id.Int ()
 
 module Activity = struct
   type t =
@@ -18,33 +15,38 @@ end
 
 module Info : sig
   type t [@@deriving compare, sexp_of]
+
   val create_exn : name:string -> value:string -> t
-  val name  : t -> string
+  val name : t -> string
   val value : t -> string
 end = struct
   type t = string * string [@@deriving compare, sexp_of]
 
   let create_exn ~name ~value =
     if String.is_empty name || String.is_empty value
-    then (failwith "One of the info fields is empty")
-    else (name, value)
+    then failwith "One of the info fields is empty"
+    else name, value
+  ;;
 
-  let name  = fst
+  let name = fst
   let value = snd
 end
 
 module Office = struct
-  type t = NYC | LDN | HKG
+  type t =
+    | NYC
+    | LDN
+    | HKG
   [@@deriving compare, sexp, enumerate]
 
   let to_string_hum = function
     | NYC -> "New York"
     | LDN -> "London"
     | HKG -> "Hong Kong"
+  ;;
 end
 
 module User = struct
-
   module Group = struct
     module T = struct
       type t =
@@ -53,94 +55,101 @@ module User = struct
         | Other
       [@@deriving compare, sexp, enumerate]
     end
+
     include T
-    include Sexpable.To_stringable(T)
+    include Sexpable.To_stringable (T)
   end
 
-
-  type t = {
-    firstname  : string;
-    lastname   : string;
-    group      : Group.t;
-    fulltime   : bool;
-    office     : Office.t;
-    activities : Activity.t list;
-    info       : Info.t list;
-  } [@@deriving compare, fields, sexp_of]
+  type t =
+    { firstname : string
+    ; lastname : string
+    ; group : Group.t
+    ; fulltime : bool
+    ; office : Office.t
+    ; activities : Activity.t list
+    ; info : Info.t list
+    }
+  [@@deriving compare, fields, sexp_of]
 
   let form =
     let open Form.Description in
     let activities_form =
-      sexp
-        ~sexp_of:[%sexp_of: Activity.t list]
-        ~of_sexp:[%of_sexp: Activity.t list]
+      sexp ~sexp_of:[%sexp_of: Activity.t list] ~of_sexp:[%of_sexp: Activity.t list]
     in
     let open Form.Description.Let_syntax in
     let unvalidated_info =
       let%map_open name = string <^ Info.name
-      and value = string <^ Info.value
-      in name, value
+      and value = string <^ Info.value in
+      name, value
     in
     let info_form =
-      conv unvalidated_info
-        ~f:(fun (name, value) (_, _) ~block_id:info_block ->
-          match Info.create_exn ~name ~value with
-          | v -> Ok v
-          | exception exn ->
-            Error [Form.Form_error.create ~id:info_block (Error.of_exn exn)]
-        )
+      conv unvalidated_info ~f:(fun (name, value) (_, _) ~block_id:info_block ->
+        match Info.create_exn ~name ~value with
+        | v -> Ok v
+        | exception exn ->
+          Error [ Form.Form_error.create ~id:info_block (Error.of_exn exn) ])
     in
     let unvalidated_user =
       let open Of_record in
-      build_for_record (
-        Fields.make_creator
-          ~firstname:(field string)
-          ~lastname:(field string)
-          ~group:(field (variant Group.all ~equal:[%compare.equal: Group.t]))
-          ~fulltime:(field bool)
-          ~office:(field (variant Office.all ~equal:[%compare.equal: Office.t]))
-          ~activities:(field activities_form)
-          ~info:(field (list info_form))
-      )
+      build_for_record
+        (Fields.make_creator
+           ~firstname:(field string)
+           ~lastname:(field string)
+           ~group:(field (variant Group.all ~equal:[%compare.equal: Group.t]))
+           ~fulltime:(field bool)
+           ~office:(field (variant Office.all ~equal:[%compare.equal: Office.t]))
+           ~activities:(field activities_form)
+           ~info:(field (list info_form)))
     in
     let user_form =
-      conv unvalidated_user
-        ~f:(fun ({ firstname; lastname; group = _; fulltime = _;
-                   office = _; activities = _; info = _; } as t)
-             (firstname_field, (lastname_field, (_, _))) ~block_id:user_block ->
-             let errors =
-               List.filter_opt
-                 [ if String.is_empty firstname
-                   then
-                     (Some (Form.Form_error.create ~id:firstname_field
-                              (Error.of_string "Firstname can't be empty")))
-                   else None
-                 ; if String.is_empty lastname
-                   then
-                     (Some (Form.Form_error.create ~id:lastname_field
-                              (Error.of_string "Lastname can't be empty")))
-                   else None
-                 ; if String.equal firstname lastname
-                   then
-                     (Some (Form.Form_error.create ~id:user_block
-                              (Error.of_string "Firstname and Lastname must be different")))
-                   else None
-                 ]
-             in
-             if List.is_empty errors
-             then (Ok t)
-             else (Error errors)
-           )
+      conv
+        unvalidated_user
+        ~f:(fun ({ firstname
+                 ; lastname
+                 ; group = _
+                 ; fulltime = _
+                 ; office = _
+                 ; activities = _
+                 ; info = _
+                 } as t)
+             (firstname_field, (lastname_field, (_, _)))
+             ~block_id:user_block
+             ->
+               let errors =
+                 List.filter_opt
+                   [ (if String.is_empty firstname
+                      then
+                        Some
+                          (Form.Form_error.create
+                             ~id:firstname_field
+                             (Error.of_string "Firstname can't be empty"))
+                      else None)
+                   ; (if String.is_empty lastname
+                      then
+                        Some
+                          (Form.Form_error.create
+                             ~id:lastname_field
+                             (Error.of_string "Lastname can't be empty"))
+                      else None)
+                   ; (if String.equal firstname lastname
+                      then
+                        Some
+                          (Form.Form_error.create
+                             ~id:user_block
+                             (Error.of_string "Firstname and Lastname must be different"))
+                      else None)
+                   ]
+               in
+               if List.is_empty errors then Ok t else Error errors)
     in
     let user_id_opt = not_editable ~default:None in
     let user_edit_form =
       let%map_open user_form = user_form <^ fst
-      and user_id_opt = user_id_opt <^ snd
-      in user_form, user_id_opt
+      and user_id_opt = user_id_opt <^ snd in
+      user_form, user_id_opt
     in
     Form.create ~name:"user edit form" user_edit_form
   ;;
-
 end
 
 let loaded_users : User.t User_id.Map.t =
@@ -148,29 +157,30 @@ let loaded_users : User.t User_id.Map.t =
     List.map tuples ~f:(fun (name, value) -> Info.create_exn ~name ~value)
   in
   let open User in
-  [ {
-    firstname = "Bobby";
-    lastname = "Tables";
-    group = Tech;
-    fulltime = false;
-    office = LDN;
-    activities = [Name "couch"];
-    info = info_list_of_tuples
-                [ "favourite language", "sql"
-                ; "achievements", "best student in school"];
-  }
-  ; {
-    firstname = "Firstname";
-    lastname = "Lastname";
-    group = Other;
-    fulltime = true;
-    office = NYC;
-    activities = [Name "ocaml"; Category ("physical",[Name "cycling"; Name "jogging"])];
-    info = info_list_of_tuples
-                [ "email", "firstname.lastname@example.com"
-                ; "joined date", "01.01.1970"
-                ; "nicknames", "First, Last, Buddy" ];
-  }
+  [ { firstname = "Bobby"
+    ; lastname = "Tables"
+    ; group = Tech
+    ; fulltime = false
+    ; office = LDN
+    ; activities = [ Name "couch" ]
+    ; info =
+        info_list_of_tuples
+          [ "favourite language", "sql"; "achievements", "best student in school" ]
+    }
+  ; { firstname = "Firstname"
+    ; lastname = "Lastname"
+    ; group = Other
+    ; fulltime = true
+    ; office = NYC
+    ; activities =
+        [ Name "ocaml"; Category ("physical", [ Name "cycling"; Name "jogging" ]) ]
+    ; info =
+        info_list_of_tuples
+          [ "email", "firstname.lastname@example.com"
+          ; "joined date", "01.01.1970"
+          ; "nicknames", "First, Last, Buddy"
+          ]
+    }
   ]
   |> List.map ~f:(fun u -> User_id.create (), u)
   |> User_id.Map.of_alist_exn
@@ -179,20 +189,24 @@ let loaded_users : User.t User_id.Map.t =
 let init =
   let i, u = Map.min_elt_exn loaded_users in
   u, Some i
+;;
 
 let form_state = Form.State.create ~init User.form
 
 module Model = struct
-  type t = {
-    form_state   : Form.State.t;
-    users        : User.t User_id.Map.t;
-    tick_counter : int;
-  } [@@deriving compare]
+  type t =
+    { form_state : Form.State.t
+    ; users : User.t User_id.Map.t
+    ; tick_counter : int
+    }
+  [@@deriving compare]
 
   let cutoff t1 t2 = compare t1 t2 = 0
 end
 
-module State = struct type t = unit end
+module State = struct
+  type t = unit
+end
 
 module Action = struct
   type t =
@@ -203,13 +217,15 @@ module Action = struct
   [@@deriving sexp_of]
 end
 
-let apply_action (model : Model.t) (action : Action.t) (_state : State.t)
+let apply_action
+      (model : Model.t)
+      (action : Action.t)
+      (_state : State.t)
       ~schedule_action:_
   : Model.t =
   match action with
-  | Tick ->
-    { model with tick_counter = succ model.tick_counter }
-  | Update_form_state form_state -> { model with form_state; }
+  | Tick -> { model with tick_counter = succ model.tick_counter }
+  | Update_form_state form_state -> { model with form_state }
   | Update_user (user, idx, form_state) ->
     let idx, next_form_state =
       match idx with
@@ -217,45 +233,45 @@ let apply_action (model : Model.t) (action : Action.t) (_state : State.t)
       | Some idx -> idx, form_state
     in
     let users = Map.set model.users ~key:idx ~data:user in
-    { model with users; form_state = next_form_state; }
+    { model with users; form_state = next_form_state }
   | Load_form u_opt ->
-    let init = Option.map u_opt ~f:(fun (u,i) -> u, Some i) in
+    let init = Option.map u_opt ~f:(fun (u, i) -> u, Some i) in
     let form_state = Form.State.create ?init User.form in
-    { model with form_state; }
+    { model with form_state }
+;;
 
 let on_startup ~schedule_action _ =
-  Async_kernel.Clock_ns.every
-    (Time_ns.Span.of_sec 5.) (fun () -> schedule_action (Action.Tick));
+  Async_kernel.Clock_ns.every (Time_ns.Span.of_sec 5.) (fun () ->
+    schedule_action Action.Tick);
   Async_kernel.return ()
+;;
 
 let view (model : Model.t Incr.t) ~inject : Vdom.Node.t Incr.t =
   let username (user : User.t) =
-    String.lowercase ((String.prefix user.firstname 1) ^ user.lastname)
+    String.lowercase (String.prefix user.firstname 1 ^ user.lastname)
   in
   let%map model = model in
   let state = model.form_state in
   let user_to_li (user_id, (user : User.t)) =
-    Node.li [] [
-      Node.span [
-        Attr.on_click (fun _evt -> inject (Action.Load_form (Some (user, user_id))))]
-        [Node.text (username user)]
-    ]
+    Node.li
+      []
+      [ Node.span
+          [ Attr.on_click (fun _evt -> inject (Action.Load_form (Some (user, user_id)))) ]
+          [ Node.text (username user) ]
+      ]
   in
   let username_list =
     let users = Map.to_alist model.users in
     Node.create "ol" [] (List.map users ~f:user_to_li)
   in
-  let
-    (user_block_id,
-     (first_id,
-      (last_id,
-       (group_id,
-        (ft_id,
-         (office_id,
-           (activities_id,
-            ((info_id_list, info_list_id),
-             ())))))))),
-    () =
+  let ( ( user_block_id
+        , ( first_id
+          , ( last_id
+            , ( group_id
+              , (ft_id, (office_id, (activities_id, ((info_id_list, info_list_id), ()))))
+              ) ) ) )
+      , () )
+    =
     Form.State.field_ids state User.form
   in
   let div_with_err id children =
@@ -264,115 +280,122 @@ let view (model : Model.t Incr.t) ~inject : Vdom.Node.t Incr.t =
       let string =
         String.strip ~drop:(fun c -> Char.equal c '"') (Error.to_string_hum err)
       in
-      Node.div [Attr.style (Css_gen.color (`Name "red"))] [ Node.text string ]
+      Node.div [ Attr.style (Css_gen.color (`Name "red")) ] [ Node.text string ]
     in
     match Form.State.error state id with
     | None -> no_err_node :: children
     | Some err -> err_node err :: children
   in
   let info_div =
-    Node.div []
-      ((Node.text "Misc information") ::
-       (List.concat_mapi info_id_list
-          ~f:(fun i (info_id, (name_id, value_id)) ->
-            div_with_err info_id
-              [ Form.Input.text state name_id []
-              ; Form.Input.text state value_id []
-              ; Node.button
-                  [ Attr.type_ "button"
-                  ; Attr.on_click (fun _evt ->
-                      let state =
-                        Form.List.remove_nth state info_list_id i
-                      in
-                      inject (Action.Update_form_state state))
-                  ] [ Node.text "Remove" ]
-              ]
-          )
-       ))
-  in
-  Node.body []
-    [ Node.p []
-        [ Node.text
-            "Enter the first and the last names, press Add button and
-             the resulting username will be added to the list."
-        ]
-    ; Node.div []
-        (div_with_err user_block_id
-           [ Node.div []
-               (div_with_err first_id
-                  [ Node.text "Firstname"
-                  ; Form.Input.text state first_id []
-                  ])
-           ; Node.div []
-               (div_with_err last_id
-                  [ Node.text "Lastname"
-                  ; Form.Input.text state last_id []
-                  ])
-           ; Node.div []
-               [(Node.text "Group")
-               ; (Form.Input.dropdown state group_id []
-                    ~compare:User.Group.compare User.Group.to_string)]
-           ; Node.div []
-               [ Node.text "Fulltime"
-               ; Form.Input.checkbox state ft_id []
+    Node.div
+      []
+      (Node.text "Misc information"
+       :: List.concat_mapi info_id_list ~f:(fun i (info_id, (name_id, value_id)) ->
+         div_with_err
+           info_id
+           [ Form.Input.text state name_id []
+           ; Form.Input.text state value_id []
+           ; Node.button
+               [ Attr.type_ "button"
+               ; Attr.on_click (fun _evt ->
+                   let state = Form.List.remove_nth state info_list_id i in
+                   inject (Action.Update_form_state state))
                ]
-           ; Node.div []
-               ((Node.div [] [Node.text "Office"]) ::
-                (
-                  let attr = [Attr.style (Css_gen.margin_left (`Em 1)) ] in
-                  Form.Input.radio_button state office_id attr
-                  |> List.concat_map ~f:(fun (opt, node) ->
-                    [ node
-                    ; Node.text (Office.to_string_hum opt)
-                    ])
-                ))
-           ; Node.div []
-               (div_with_err activities_id
+               [ Node.text "Remove" ]
+           ]))
+  in
+  Node.body
+    []
+    [ Node.p
+        []
+        [ Node.text
+            "Enter the first and the last names, press Add button and\n\
+            \             the resulting username will be added to the list."
+        ]
+    ; Node.div
+        []
+        (div_with_err
+           user_block_id
+           [ Node.div
+               []
+               (div_with_err
+                  first_id
+                  [ Node.text "Firstname"; Form.Input.text state first_id [] ])
+           ; Node.div
+               []
+               (div_with_err
+                  last_id
+                  [ Node.text "Lastname"; Form.Input.text state last_id [] ])
+           ; Node.div
+               []
+               [ Node.text "Group"
+               ; Form.Input.dropdown
+                   state
+                   group_id
+                   []
+                   ~compare:User.Group.compare
+                   User.Group.to_string
+               ]
+           ; Node.div [] [ Node.text "Fulltime"; Form.Input.checkbox state ft_id [] ]
+           ; Node.div
+               []
+               (Node.div [] [ Node.text "Office" ]
+                ::
+                (let attr = [ Attr.style (Css_gen.margin_left (`Em 1)) ] in
+                 Form.Input.radio_button state office_id attr
+                 |> List.concat_map ~f:(fun (opt, node) ->
+                   [ node; Node.text (Office.to_string_hum opt) ])))
+           ; Node.div
+               []
+               (div_with_err
+                  activities_id
                   [ Node.text "Activities"
                   ; Node.div [] []
                   ; Form.Input.textarea state activities_id []
                   ])
            ; info_div
-           ; Node.div []
+           ; Node.div
+               []
                [ Node.button
                    [ Attr.type_ "button"
                    ; Attr.on_click (fun _evt ->
                        let list_adder =
                          { Form.List.transform =
-                             fun list ~create_new_form ->
-                               list @ [create_new_form ()]
-                         } in
+                             (fun list ~create_new_form ->
+                                list @ [ create_new_form () ])
+                         }
+                       in
                        let state =
                          Form.List.modify_list state info_list_id ~f:list_adder
                        in
                        inject (Action.Update_form_state state))
-                   ] [ Node.text "Add" ]
+                   ]
+                   [ Node.text "Add" ]
                ]
            ; Node.button
                [ Attr.type_ "button"
                ; Attr.on_click (fun _evt ->
-                   let user_idx_opt, new_state = Form.State.read_value state User.form in
+                   let user_idx_opt, new_state =
+                     Form.State.read_value state User.form
+                   in
                    match user_idx_opt with
                    | None -> inject (Action.Update_form_state new_state)
-                   | Some (user, user_id) -> inject (Action.Update_user (user, user_id, new_state))
-                 )
-               ] [ Node.text "Submit" ]
+                   | Some (user, user_id) ->
+                     inject (Action.Update_user (user, user_id, new_state)))
+               ]
+               [ Node.text "Submit" ]
            ; Node.button
                [ Attr.type_ "button"
                ; Attr.on_click (fun _evt -> inject (Action.Load_form None))
-               ] [ Node.text "New" ]
-           ]
-        )
+               ]
+               [ Node.text "New" ]
+           ])
     ; Node.create "hr" [] []
     ; username_list
     ]
+;;
 
-let initial_model () =
-  { Model.
-    form_state;
-    users = loaded_users;
-    tick_counter = 0;
-  }
+let initial_model () = { Model.form_state; users = loaded_users; tick_counter = 0 }
 
 let create model ~old_model:_ ~inject =
   let%map apply_action =
@@ -381,3 +404,4 @@ let create model ~old_model:_ ~inject =
   and view = view model ~inject
   and model = model in
   Component.create ~apply_action model view
+;;

--- a/example/username_gen/main.ml
+++ b/example/username_gen/main.ml
@@ -2,3 +2,4 @@ open Incr_dom
 
 let () =
   Start_app.component_old_do_not_use (module App) ~initial_model:(App.initial_model ())
+;;

--- a/incr_dom_widgets.opam
+++ b/incr_dom_widgets.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "v0.12.0"
 maintainer: "opensource@janestreet.com"
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/incr_dom_widgets"
@@ -10,17 +11,17 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
-  "async_js"
-  "async_kernel"
-  "incr_dom"
-  "incr_map"
-  "incr_select"
-  "incremental"
-  "ppx_jane"
-  "record_builder"
-  "splay_tree"
-  "virtual_dom"
+  "ocaml"           {>= "4.07.0"}
+  "async_js"        {>= "v0.12" & < "v0.13"}
+  "async_kernel"    {>= "v0.12" & < "v0.13"}
+  "incr_dom"        {>= "v0.12" & < "v0.13"}
+  "incr_map"        {>= "v0.12" & < "v0.13"}
+  "incr_select"     {>= "v0.12" & < "v0.13"}
+  "incremental"     {>= "v0.12" & < "v0.13"}
+  "ppx_jane"        {>= "v0.12" & < "v0.13"}
+  "record_builder"  {>= "v0.12" & < "v0.13"}
+  "splay_tree"      {>= "v0.12" & < "v0.13"}
+  "virtual_dom"     {>= "v0.12" & < "v0.13"}
   "dune"            {build & >= "1.5.1"}
   "js_of_ocaml"     {>= "3.2.1"}
   "js_of_ocaml-ppx"

--- a/src/buttons.ml
+++ b/src/buttons.ml
@@ -1,0 +1,60 @@
+open! Core_kernel
+open Incr_dom.Vdom
+
+module Style = struct
+  type t =
+    | Default
+    | Primary
+    | Secondary
+    | Disabled
+
+  let to_attr t =
+    match t with
+    | Default -> None
+    | Primary -> Some (Attr.class_ "primary")
+    | Secondary -> Some (Attr.class_ "secondary")
+    | Disabled -> Some Attr.disabled
+  ;;
+end
+
+type button_creator =
+  ?extra_classes:Attr.t list
+  -> ?on_click:(Js_of_ocaml.Dom_html.mouseEvent Js_of_ocaml.Js.t -> Event.t)
+  -> ?outlined:bool
+  -> ?compact:bool
+  -> ?title:string
+  -> text:string
+  -> unit
+  -> Node.t
+
+let button
+      ~style
+      ?(extra_classes = [])
+      ?on_click
+      ?(outlined = false)
+      ?(compact = false)
+      ?title
+      ~text
+      ()
+  =
+  let on_click = Option.map on_click ~f:Attr.on_click |> Option.to_list in
+  let title = Option.map title ~f:(Attr.create "title") |> Option.to_list in
+  let outlined = if outlined then [ Attr.class_ "outlined" ] else [] in
+  let compact = if compact then [ Attr.class_ "compact" ] else [] in
+  let style = Style.to_attr style |> Option.to_list in
+  Node.button
+    (Attrs.merge_classes_and_styles
+       ([ Attr.class_ "clickable" ]
+        @ style
+        @ on_click
+        @ title
+        @ outlined
+        @ compact
+        @ extra_classes))
+    [ Node.text text ]
+;;
+
+let default = button ~style:Style.Default
+let primary = button ~style:Style.Primary
+let secondary = button ~style:Style.Secondary
+let disabled = button ~style:Style.Disabled

--- a/src/buttons.mli
+++ b/src/buttons.mli
@@ -1,0 +1,18 @@
+open! Core_kernel
+open Incr_dom.Vdom
+
+
+type button_creator =
+  ?extra_classes:Attr.t list
+  -> ?on_click:(Js_of_ocaml.Dom_html.mouseEvent Js_of_ocaml.Js.t -> Event.t)
+  -> ?outlined:bool
+  -> ?compact:bool
+  -> ?title:string
+  -> text:string
+  -> unit
+  -> Node.t
+
+val default : button_creator
+val primary : button_creator
+val secondary : button_creator
+val disabled : button_creator

--- a/src/form.ml
+++ b/src/form.ml
@@ -778,6 +778,13 @@ module Input = struct
     in
     Node.select ~key:id (Attr.id id :: attr) (List.map sorted_options ~f:snd)
   ;;
+
+  let label id attr =
+    let id = Id.to_string id in
+    let attr = (Attr.for_ id) :: attr in
+    Node.label attr
+  ;;
+
 end
 
 module List = struct

--- a/src/form.ml
+++ b/src/form.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-
 open! Int.Replace_polymorphic_compare
 
 (** Add a unique identity to things which is comparable. *)
@@ -8,22 +7,20 @@ module Identified : sig
 
   type +'a t = private Identified of Id.t * 'a
 
-  val create  : 'a -> 'a t
+  val create : 'a -> 'a t
   val extract : 'a t -> 'a
-
   val compare : _ t -> _ t -> int
 
   (** The id comparison corresponds with the regular comparison. *)
   val id : _ t -> Id.t
 end = struct
-  module Id = Unique_id.Int()
+  module Id = Unique_id.Int ()
 
   type +'a t = Identified of Id.t * 'a
 
   let create x = Identified (Id.create (), x)
   let extract (Identified (_, x)) = x
   let id (Identified (id, _)) = id
-
   let compare (Identified (l, _)) (Identified (r, _)) = Id.compare l r
 end
 
@@ -34,16 +31,15 @@ end
 module Id : sig
   type 'a t
 
-  val create_string  : prefix:string -> string t
-  val create_bool    : prefix:string -> bool t
-  val create_block   : prefix:string -> Block.t t
-
-  val extend_prefix  : prefix:string -> string
-
+  val create_string : prefix:string -> string t
+  val create_bool : prefix:string -> bool t
+  val create_block : prefix:string -> Block.t t
+  val extend_prefix : prefix:string -> string
   val to_string : _ t -> string
 
   module Pack : sig
     include Comparable.S
+
     val to_string : t -> string
   end
 
@@ -52,44 +48,44 @@ module Id : sig
 end = struct
   type 'a t = string
 
-  module I = Unique_id.Int()
+  module I = Unique_id.Int ()
   module Pack = String
 
   let to_string s = s
-  let create_string  ~prefix = sprintf !"%s_f%{I}" prefix (I.create ())
-  let create_bool    ~prefix = sprintf !"%s_f%{I}" prefix (I.create ())
-  let create_block   ~prefix = sprintf !"%s_b%{I}" prefix (I.create ())
-  let extend_prefix  ~prefix = sprintf !"%s_p%{I}" prefix (I.create ())
-
+  let create_string ~prefix = sprintf !"%s_f%{I}" prefix (I.create ())
+  let create_bool ~prefix = sprintf !"%s_f%{I}" prefix (I.create ())
+  let create_block ~prefix = sprintf !"%s_b%{I}" prefix (I.create ())
+  let extend_prefix ~prefix = sprintf !"%s_p%{I}" prefix (I.create ())
   let pack s = s
 end
 
 module Variant_id = struct
-  type 'a t = {
-    options  : 'a array;
-    equal    : 'a -> 'a -> bool;
-    field_id : string Id.t;
-  }
+  type 'a t =
+    { options : 'a array
+    ; equal : 'a -> 'a -> bool
+    ; field_id : string Id.t
+    }
 end
 
 module Field = struct
-
   type 'a t =
-    | Bool    : bool   t
-    | String  : string t
+    | Bool : bool t
+    | String : string t
 
   type pack = Pack : 'a t * 'a option -> pack
 
-  let compare_pack l r = match l, r with
+  let compare_pack l r =
+    match l, r with
     | Pack (Bool, _), Pack (String, _) -> -1
     | Pack (String, _), Pack (Bool, _) -> 1
     | Pack (Bool, l), Pack (Bool, r) -> Option.compare Bool.compare l r
     | Pack (String, l), Pack (String, r) -> Option.compare String.compare l r
   ;;
 
-  let generate_id (type a) (t : a t) ~prefix : a Id.t = match t with
-    | Bool    -> Id.create_bool    ~prefix
-    | String  -> Id.create_string  ~prefix
+  let generate_id (type a) (t : a t) ~prefix : a Id.t =
+    match t with
+    | Bool -> Id.create_bool ~prefix
+    | String -> Id.create_string ~prefix
   ;;
 end
 
@@ -97,7 +93,6 @@ module Form_error = struct
   type t = Pack : 'a Id.t * Error.t -> t
 
   let create reason ~id = Pack (id, reason)
-
   let of_string string ~id = create ~id (Error.createf !"%{Id}: %s" id string)
 end
 
@@ -108,58 +103,57 @@ module List_id = struct
 end
 
 module Description = struct
-
   type ('g, 's, 'ids) t =
     | Not_editable : 'a -> ('a, 'a, unit) t
     | Field : 'a Field.t -> ('a, 'a, 'a Id.t) t
-    | Pair  : ('a, 's, 'a_ids) t * ('b, 's, 'b_ids) t ->
-      ('a * 'b, 's, 'a_ids * 'b_ids) t
+    | Pair : ('a, 's, 'a_ids) t * ('b, 's, 'b_ids) t -> ('a * 'b, 's, 'a_ids * 'b_ids) t
     | Map : ('a, 's, 'ids) t * ('a -> 'b) -> ('b, 's, 'ids) t
     | Contra_map : ('g, 'b, 'ids) t * ('a -> 'b) -> ('g, 'a, 'ids) t
     | Map_ids : ('g, 's, 'a_ids) t * ('a_ids -> 'b_ids) -> ('g, 's, 'b_ids) t
-    | Conv : {
-        inner : ('a, 's, 'ids) t;
-        to_outer : ('a -> 'ids -> block_id:Block.t Id.t -> ('b, Form_error.t list) Result.t);
-      } -> ('b, 's, Block.t Id.t * 'ids) t
+    | Conv :
+        { inner : ('a, 's, 'ids) t
+        ; to_outer :
+            'a -> 'ids -> block_id:Block.t Id.t -> ('b, Form_error.t list) Result.t
+        }
+      -> ('b, 's, Block.t Id.t * 'ids) t
     | List : ('g, 's, 'ids) t -> ('g list, 's list, 'ids list * 's List_id.t) t
 
   let not_editable ~default = Not_editable default
   let string = Field String
-  let bool   = Field Bool
-
+  let bool = Field Bool
   let both a b = Pair (a, b)
   let map x ~f = Map (x, f)
   let contra_map x ~f = Contra_map (x, f)
   let map_ids x ~f = Map_ids (x, f)
-
   let conv inner ~f:to_outer = Conv { inner; to_outer }
+
   let conv_without_block inner ~f:to_outer =
     conv inner ~f:(fun a ids ~block_id:_ -> to_outer a ids)
     |> map_ids ~f:(fun (_block_id, ids) -> ids)
   ;;
+
   let list el_desc = List el_desc
 
   let sexp ~of_sexp ~sexp_of =
-    conv_without_block string
-      ~f:(fun string string_id ->
-        match of_sexp (Sexp.of_string string) with
-        | x -> Ok x
-        | exception exn ->
-          Error [Form_error.create ~id:string_id (Error.of_exn exn)])
+    conv_without_block string ~f:(fun string string_id ->
+      match of_sexp (Sexp.of_string string) with
+      | x -> Ok x
+      | exception exn -> Error [ Form_error.create ~id:string_id (Error.of_exn exn) ])
     |> contra_map ~f:(fun a -> Sexp.to_string (sexp_of a))
   ;;
 
   let rec has_duplicated_value values equal =
     match values with
-    | [] | [_] -> false
-    | x :: xs  -> List.mem xs x ~equal || has_duplicated_value xs equal
+    | []
+    | [ _ ] -> false
+    | x :: xs -> List.mem xs x ~equal || has_duplicated_value xs equal
   ;;
 
   let valid_variant_options_exn list equal =
     if List.is_empty list
-    then (failwith "Variant options cannot be an empty list.")
+    then failwith "Variant options cannot be an empty list."
     else if has_duplicated_value list equal
-    then (failwith "Variant options must have unique values.")
+    then failwith "Variant options must have unique values."
     else list
   ;;
 
@@ -170,20 +164,19 @@ module Description = struct
         let idx = Int.of_string s_idx in
         if idx >= 0 && idx < Array.length options
         then options.(idx)
-        else (failwith "Selected variant option does not belong to the options list"))
+        else failwith "Selected variant option does not belong to the options list")
     in
     let variant_to_from_string =
       contra_map variant_from_string ~f:(fun x ->
         let index_opt =
-          Array.find_mapi options ~f:(fun i opt ->
-            Option.some_if (equal x opt) i)
+          Array.find_mapi options ~f:(fun i opt -> Option.some_if (equal x opt) i)
         in
-        match index_opt  with
+        match index_opt with
         | Some idx -> Int.to_string idx
         | None -> failwith "Initial variant value does not belong to the options list")
     in
-    map_ids variant_to_from_string
-      ~f:(fun field_id -> { Variant_id.options; equal; field_id; })
+    map_ids variant_to_from_string ~f:(fun field_id ->
+      { Variant_id.options; equal; field_id })
   ;;
 
   module Let_syntax = struct
@@ -192,9 +185,8 @@ module Description = struct
       let both = both
 
       module Open_on_rhs = struct
-        let (<^) x f = contra_map x ~f
-        let (^<) f x = map x ~f
-
+        let ( <^ ) x f = contra_map x ~f
+        let ( ^< ) f x = map x ~f
         let string = string
         let bool = bool
         let list = list
@@ -222,57 +214,64 @@ module Description = struct
 
       let nil = Nil
 
-      let cons (type x xs i id ids)
-            (x : (x, i, id) descr) (xs : (xs, i, ids) t)
-        : (x * xs, i, id * ids) t
-        = match xs with
+      let cons (type x xs i id ids) (x : (x, i, id) descr) (xs : (xs, i, ids) t)
+        : (x * xs, i, id * ids) t =
+        match xs with
         | Nil -> Cons (map_ids (map x ~f:(fun x -> x, ())) ~f:(fun ids -> ids, ()))
         | Cons xs -> Cons (both x xs)
       ;;
 
-      let unpack ((Cons xs) : (_ Hlist.nonempty, _, _ Hlist.nonempty) t) = xs
+      let unpack (Cons xs : (_ Hlist.nonempty, _, _ Hlist.nonempty) t) = xs
     end
 
     module Make_creator_types = struct
       type ('tail, 'tail_ids, 'all_fields, 'all_ids, 'record) accum =
-        (('tail, 'record, 'tail_ids) Hlist_T.t -> ('all_fields, 'record, 'all_ids) Hlist_T.t)
+        (('tail, 'record, 'tail_ids) Hlist_T.t
+         -> ('all_fields, 'record, 'all_ids) Hlist_T.t)
         * ('all_fields, 'tail) Hlist.Suffix_index.t
 
       type ('field, 'head, 'head_ids, 'tail, 'tail_ids, 'all_fields, 'all_ids, 'record) fold_step =
         ('head, 'head_ids, 'all_fields, 'all_ids, 'record) accum
-        -> ('all_fields -> 'field) * ('tail, 'tail_ids, 'all_fields, 'all_ids, 'record) accum
+        -> ('all_fields -> 'field)
+           * ('tail, 'tail_ids, 'all_fields, 'all_ids, 'record) accum
 
       type ('field, 'field_ids, 'tail, 'tail_ids, 'all_fields, 'all_ids, 'record) handle_one_field =
         ( 'field
-        , ('field, 'tail) Hlist.cons, ('field_ids, 'tail_ids) Hlist.cons
-        , 'tail, 'tail_ids
-        , 'all_fields Hlist.nonempty, 'all_ids Hlist.nonempty
-        , 'record
-        ) fold_step
+        , ('field, 'tail) Hlist.cons
+        , ('field_ids, 'tail_ids) Hlist.cons
+        , 'tail
+        , 'tail_ids
+        , 'all_fields Hlist.nonempty
+        , 'all_ids Hlist.nonempty
+        , 'record )
+          fold_step
 
       type ('all_fields, 'all_ids, 'record) handle_all_fields =
         ( 'record
-        , 'all_fields Hlist.nonempty, 'all_ids Hlist.nonempty
-        , Hlist.nil, Hlist.nil
-        , 'all_fields Hlist.nonempty, 'all_ids Hlist.nonempty
-        , 'record) fold_step
+        , 'all_fields Hlist.nonempty
+        , 'all_ids Hlist.nonempty
+        , Hlist.nil
+        , Hlist.nil
+        , 'all_fields Hlist.nonempty
+        , 'all_ids Hlist.nonempty
+        , 'record )
+          fold_step
     end
 
     let field form field (build_hlist, suffix) =
       let build_hlist =
-        Fn.compose build_hlist (Hlist_T.cons (contra_map ~f:(Core_kernel.Field.get field) form))
+        Fn.compose
+          build_hlist
+          (Hlist_T.cons (contra_map ~f:(Core_kernel.Field.get field) form))
       and get_field =
         let index = Hlist.Element_index.(within ~suffix first_element) in
         fun hlist -> Hlist.nth hlist index
-      and suffix = Hlist.Suffix_index.tail_of suffix
-      in
+      and suffix = Hlist.Suffix_index.tail_of suffix in
       get_field, (build_hlist, suffix)
     ;;
 
     let build_for_record folding =
-      let from_values, (build_up, _) =
-        folding (Fn.id, Hlist.Suffix_index.whole_list)
-      in
+      let from_values, (build_up, _) = folding (Fn.id, Hlist.Suffix_index.whole_list) in
       map (Hlist_T.unpack (build_up Hlist_T.nil)) ~f:from_values
     ;;
   end
@@ -280,18 +279,16 @@ module Description = struct
   type ('a, 'ids) closed = ('a, 'a, 'ids) t
 end
 
-type ('a, 'ids) t = {
-  description : ('a, 'ids) Description.closed;
-  witness     : (('a, 'ids) Description.closed) Type_equal.Id.t;
-}
+type ('a, 'ids) t =
+  { description : ('a, 'ids) Description.closed
+  ; witness : ('a, 'ids) Description.closed Type_equal.Id.t
+  }
 
 type ('a, 'ids) form = ('a, 'ids) t
 
 let create ~name description =
-  {
-    description;
-    witness = Type_equal.Id.create ~name sexp_of_opaque;
-  }
+  { description; witness = Type_equal.Id.create ~name sexp_of_opaque }
+;;
 
 let to_description { description; witness = _ } = description
 
@@ -302,34 +299,40 @@ module State = struct
     type ('g, 's, 'ids) t =
       | Not_editable : 'a -> ('a, 'a, unit) t
       | Field : 'a Field.t * 'a option * 'a Id.t -> ('a, 'a, 'a Id.t) t
-      | Pair  : ('a, 's, 'a_ids) t * ('b, 's, 'b_ids) t -> ('a * 'b, 's, 'a_ids * 'b_ids) t
+      | Pair :
+          ('a, 's, 'a_ids) t * ('b, 's, 'b_ids) t
+        -> ('a * 'b, 's, 'a_ids * 'b_ids) t
       | Map : ('a, 's, 'ids) t * ('a -> 'b) -> ('b, 's, 'ids) t
       | Contra_map : ('g, 'b, 'ids) t * ('a -> 'b) -> ('g, 'a, 'ids) t
       | Map_ids : ('g, 's, 'a_ids) t * ('a_ids -> 'b_ids) -> ('g, 's, 'b_ids) t
-      | Conv : {
-          inner    : ('a, 's, 'ids) t;
-          to_outer : ('a -> 'ids -> block_id:Block.t Id.t -> ('b, Form_error.t list) Result.t);
-          block_id : Block.t Id.t
-        } -> ('b, 's, Block.t Id.t * 'ids) t
-      | List : ('g, 's, 'ids) params Type_equal.Id.t
+      | Conv :
+          { inner : ('a, 's, 'ids) t
+          ; to_outer :
+              'a -> 'ids -> block_id:Block.t Id.t -> ('b, Form_error.t list) Result.t
+          ; block_id : Block.t Id.t
+          }
+        -> ('b, 's, Block.t Id.t * 'ids) t
+      | List :
+          ('g, 's, 'ids) params Type_equal.Id.t
         -> ('g list, 's list, 'ids list * 's List_id.t) t
 
     module Of_list = struct
       type ('g, 's, 'ids) state = ('g, 's, 'ids) t
 
-      type t = Of_list : {
-        witness : ('g, 's, 'ids) params Type_equal.Id.t;
-        el_desc : ('g, 's, 'ids) Description.t Identified.t;
-        list : ('g, 's, 'ids) state Identified.t list;
-        prefix : string;
-      } -> t
+      type t =
+        | Of_list :
+            { witness : ('g, 's, 'ids) params Type_equal.Id.t
+            ; el_desc : ('g, 's, 'ids) Description.t Identified.t
+            ; list : ('g, 's, 'ids) state Identified.t list
+            ; prefix : string
+            }
+          -> t
 
       let compare =
         Comparable.lexicographic
-          [ Comparable.lift [%compare: Type_equal.Id.Uid.t]
-              ~f:(fun (Of_list t) -> Type_equal.Id.uid t.witness)
-          ; Comparable.lift [%compare: string]
-              ~f:(fun (Of_list t) -> t.prefix)
+          [ Comparable.lift [%compare: Type_equal.Id.Uid.t] ~f:(fun (Of_list t) ->
+              Type_equal.Id.uid t.witness)
+          ; Comparable.lift [%compare: string] ~f:(fun (Of_list t) -> t.prefix)
           ; (fun (Of_list l) (Of_list r) -> Identified.compare l.el_desc r.el_desc)
           ; (fun (Of_list l) (Of_list r) ->
                let Type_equal.T = Type_equal.Id.same_witness_exn l.witness r.witness in
@@ -344,44 +347,46 @@ module State = struct
   type ('a, 'ids) closed = ('a, 'a, 'ids) State.t
 
   module List_states = struct
-    type t = State.Of_list.t Type_equal.Id.Uid.Map.t
-    [@@deriving compare]
+    type t = State.Of_list.t Type_equal.Id.Uid.Map.t [@@deriving compare]
   end
 
   (** Used for generating unique prefixes. *)
-  module Form_id = Unique_id.Int()
+  module Form_id = Unique_id.Int ()
 
-  type t = Pack : {
-    witness  : (('a, 'ids) Description.closed) Type_equal.Id.t;
-    state    : ('a, 'ids) closed Identified.t;
-    fields   : Field.pack Id.Pack.Map.t;
-    errors   : Error.t Id.Pack.Map.t;
-    uid_set  : Id.Pack.Set.t;
-    list_map : List_states.t;
-  } -> t
+  type t =
+    | Pack :
+        { witness : ('a, 'ids) Description.closed Type_equal.Id.t
+        ; state : ('a, 'ids) closed Identified.t
+        ; fields : Field.pack Id.Pack.Map.t
+        ; errors : Error.t Id.Pack.Map.t
+        ; uid_set : Id.Pack.Set.t
+        ; list_map : List_states.t
+        }
+      -> t
 
   let compare =
     Comparable.lexicographic
-      [ Comparable.lift [%compare: Type_equal.Id.Uid.t]
-          ~f:(fun (Pack t) -> Type_equal.Id.uid t.witness)
-      ; Comparable.lift [%compare: Identified.Id.t]
-          ~f:(fun (Pack t) -> Identified.id t.state)
-      ; Comparable.lift [%compare: Field.pack Id.Pack.Map.t]
-          ~f:(fun (Pack t) -> t.fields)
-      ; Comparable.lift [%compare: Error.t Id.Pack.Map.t]
-          ~f:(fun (Pack t) -> t.errors)
-      ; Comparable.lift [%compare: Id.Pack.Set.t]
-          ~f:(fun (Pack t) -> t.uid_set)
-      ; Comparable.lift [%compare: List_states.t]
-          ~f:(fun (Pack t) -> t.list_map)
+      [ Comparable.lift [%compare: Type_equal.Id.Uid.t] ~f:(fun (Pack t) ->
+          Type_equal.Id.uid t.witness)
+      ; Comparable.lift [%compare: Identified.Id.t] ~f:(fun (Pack t) ->
+          Identified.id t.state)
+      ; Comparable.lift [%compare: Field.pack Id.Pack.Map.t] ~f:(fun (Pack t) -> t.fields)
+      ; Comparable.lift [%compare: Error.t Id.Pack.Map.t] ~f:(fun (Pack t) -> t.errors)
+      ; Comparable.lift [%compare: Id.Pack.Set.t] ~f:(fun (Pack t) -> t.uid_set)
+      ; Comparable.lift [%compare: List_states.t] ~f:(fun (Pack t) -> t.list_map)
       ]
   ;;
 
   let merge_disjoint_maps_exn l r =
-    Map.merge l r ~f:(fun ~key data -> match data with
-      | `Left x | `Right x -> Some x
-      | `Both _ -> failwithf !"merge_disjoint_maps: Key in both maps: %{Sexp}"
-                     ((Map.comparator l).Comparator.sexp_of_t key) ())
+    Map.merge l r ~f:(fun ~key data ->
+      match data with
+      | `Left x
+      | `Right x -> Some x
+      | `Both _ ->
+        failwithf
+          !"merge_disjoint_maps: Key in both maps: %{Sexp}"
+          ((Map.comparator l).Comparator.sexp_of_t key)
+          ())
   ;;
 
   let rec fields : type g s ids.
@@ -392,21 +397,21 @@ module State = struct
       | Field (field, init, field_id) ->
         let id_pack = Id.pack field_id in
         Id.Pack.Map.singleton id_pack (Field.Pack (field, init))
-      | Pair (a, b) ->
-        merge_disjoint_maps_exn (fields a list_map) (fields b list_map)
+      | Pair (a, b) -> merge_disjoint_maps_exn (fields a list_map) (fields b list_map)
       | Map (inner, _) -> fields inner list_map
       | Contra_map (inner, _) -> fields inner list_map
       | Map_ids (inner, _) -> fields inner list_map
-      | Conv { inner; to_outer = _; block_id = _; } -> fields inner list_map
+      | Conv { inner; to_outer = _; block_id = _ } -> fields inner list_map
       | List witness ->
-        let (Of_list.Of_list list_state) = Map.find_exn list_map (Type_equal.Id.uid witness) in
+        let (Of_list.Of_list list_state) =
+          Map.find_exn list_map (Type_equal.Id.uid witness)
+        in
         List.map list_state.list ~f:(fun (Identified (_, t)) -> fields t list_map)
         |> List.reduce_balanced ~f:merge_disjoint_maps_exn
         |> Option.value ~default:Id.Pack.Map.empty
   ;;
 
-  let rec uid_set : type g s ids.
-    (g, s, ids) State.t -> List_states.t -> Id.Pack.Set.t =
+  let rec uid_set : type g s ids. (g, s, ids) State.t -> List_states.t -> Id.Pack.Set.t =
     fun t list_map ->
       match t with
       | Not_editable _ -> Id.Pack.Set.empty
@@ -415,18 +420,21 @@ module State = struct
       | Map (inner, _) -> uid_set inner list_map
       | Contra_map (inner, _) -> uid_set inner list_map
       | Map_ids (inner, _) -> uid_set inner list_map
-      | Conv { inner; to_outer = _; block_id; } ->
+      | Conv { inner; to_outer = _; block_id } ->
         Id.Pack.Set.add (uid_set inner list_map) (Id.pack block_id)
       | List witness ->
-        let (Of_list.Of_list list_state) = Map.find_exn list_map (Type_equal.Id.uid witness) in
+        let (Of_list.Of_list list_state) =
+          Map.find_exn list_map (Type_equal.Id.uid witness)
+        in
         List.map list_state.list ~f:(fun (Identified (_, t)) -> uid_set t list_map)
         |> Id.Pack.Set.union_list
   ;;
 
   let rec create' : type g s ids.
-    init:s option ->
-    (g, s, ids) Description.t -> prefix:string ->
-    (g, s, ids) State.t * List_states.t =
+    init:s option
+    -> (g, s, ids) Description.t
+    -> prefix:string
+    -> (g, s, ids) State.t * List_states.t =
     fun ~init t ~prefix ->
       match t with
       | Description.Not_editable default ->
@@ -455,48 +463,64 @@ module State = struct
         let prefix = Id.extend_prefix ~prefix in
         let init = Option.value init ~default:[] in
         let forms, all_list_states =
-          List.unzip (List.map init ~f:(fun init ->
-            let state, list_states =
-              create' el_desc ~init:(Some init) ~prefix
-            in
-            Identified.create state, list_states))
+          List.unzip
+            (List.map init ~f:(fun init ->
+               let state, list_states = create' el_desc ~init:(Some init) ~prefix in
+               Identified.create state, list_states))
         in
         let list_states =
-          Option.value ~default:Type_equal.Id.Uid.Map.empty (
-            List.reduce_balanced ~f:merge_disjoint_maps_exn all_list_states)
+          Option.value
+            ~default:Type_equal.Id.Uid.Map.empty
+            (List.reduce_balanced ~f:merge_disjoint_maps_exn all_list_states)
         in
         let witness = Type_equal.Id.create ~name:prefix sexp_of_opaque in
         let el_desc = Identified.create el_desc in
-        let list_desc = Of_list.Of_list { witness; el_desc; list = forms; prefix; }  in
+        let list_desc = Of_list.Of_list { witness; el_desc; list = forms; prefix } in
         List witness, Map.set list_states ~key:(Type_equal.Id.uid witness) ~data:list_desc
   ;;
 
-  let create ?init {description; witness} =
+  let create ?init { description; witness } =
     let prefix = sprintf !"form%{Form_id}" (Form_id.create ()) in
     let state, list_map = create' description ~init ~prefix in
     let uid_set = uid_set state list_map in
     let fields = fields state list_map in
-    Pack { witness; state = Identified.create state; fields; uid_set; errors = Id.Pack.Map.empty; list_map }
+    Pack
+      { witness
+      ; state = Identified.create state
+      ; fields
+      ; uid_set
+      ; errors = Id.Pack.Map.empty
+      ; list_map
+      }
   ;;
 
   (* Returns the keys in an arbitrary order. *)
   let rec collect_list_keys_in_use : type g s ids.
-    (g, s, ids) State.t -> list_map:List_states.t
-    -> tail:Type_equal.Id.Uid.t list -> Type_equal.Id.Uid.t list =
+    (g, s, ids) State.t
+    -> list_map:List_states.t
+    -> tail:Type_equal.Id.Uid.t list
+    -> Type_equal.Id.Uid.t list =
     fun t ~list_map ~tail ->
       match t with
       | Not_editable _ -> tail
       | Field _ -> tail
       | Pair (a, b) ->
-        collect_list_keys_in_use a ~list_map ~tail:(collect_list_keys_in_use b ~list_map ~tail)
+        collect_list_keys_in_use
+          a
+          ~list_map
+          ~tail:(collect_list_keys_in_use b ~list_map ~tail)
       | Map (inner, _) -> collect_list_keys_in_use inner ~list_map ~tail
       | Contra_map (inner, _) -> collect_list_keys_in_use inner ~list_map ~tail
       | Map_ids (inner, _) -> collect_list_keys_in_use inner ~list_map ~tail
-      | Conv { inner; to_outer = _; block_id = _; } ->
+      | Conv { inner; to_outer = _; block_id = _ } ->
         collect_list_keys_in_use inner ~list_map ~tail
       | List witness ->
-        let (Of_list.Of_list list_state) = Map.find_exn list_map (Type_equal.Id.uid witness) in
-        List.fold list_state.list ~init:(Type_equal.Id.uid witness :: tail)
+        let (Of_list.Of_list list_state) =
+          Map.find_exn list_map (Type_equal.Id.uid witness)
+        in
+        List.fold
+          list_state.list
+          ~init:(Type_equal.Id.uid witness :: tail)
           ~f:(fun tail inner_state ->
             collect_list_keys_in_use (Identified.extract inner_state) ~list_map ~tail)
   ;;
@@ -505,7 +529,8 @@ module State = struct
     match Type_equal.Id.same_witness form.witness t_witness with
     | Some x -> x
     | None ->
-      failwithf "state not matching description: %s <> %s"
+      failwithf
+        "state not matching description: %s <> %s"
         (Type_equal.Id.name form.witness)
         (Type_equal.Id.name t_witness)
         ()
@@ -520,13 +545,14 @@ module State = struct
       | Map (inner, _) -> field_ids' inner list_map
       | Contra_map (inner, _) -> field_ids' inner list_map
       | Map_ids (inner, f) -> f (field_ids' inner list_map)
-      | Conv { inner; to_outer = _; block_id; } -> block_id, field_ids' inner list_map
+      | Conv { inner; to_outer = _; block_id } -> block_id, field_ids' inner list_map
       | List witness ->
-        let (Of_list.Of_list list_state) = Map.find_exn list_map (Type_equal.Id.uid witness) in
+        let (Of_list.Of_list list_state) =
+          Map.find_exn list_map (Type_equal.Id.uid witness)
+        in
         let Type_equal.T = Type_equal.Id.same_witness_exn witness list_state.witness in
         let inner_ids =
-          List.map list_state.list ~f:(fun t ->
-            field_ids' (Identified.extract t) list_map)
+          List.map list_state.list ~f:(fun t -> field_ids' (Identified.extract t) list_map)
         in
         inner_ids, List_id.List_id witness
   ;;
@@ -535,26 +561,28 @@ module State = struct
     fun (Pack t) form ->
       let Type_equal.T = require_witness_matches_exn ~form t.witness in
       field_ids' (Identified.extract t.state) t.list_map
+  ;;
 
   let getElementById id = Dom_html.document##getElementById (Js.string id)
 
   let get_with_tagged_element id ~f =
     match Dom_html.opt_tagged (getElementById (Id.to_string id)) with
-    | None     -> Error [Form_error.of_string "element not found" ~id]
-    | Some elt -> Result.map_error (f elt) ~f:(fun msg -> [Form_error.of_string msg ~id])
+    | None -> Error [ Form_error.of_string "element not found" ~id ]
+    | Some elt ->
+      Result.map_error (f elt) ~f:(fun msg -> [ Form_error.of_string msg ~id ])
   ;;
 
   let string_value tagged_element =
     match tagged_element with
-    | Dom_html.Input el    -> Ok (Js.to_string el##.value)
+    | Dom_html.Input el -> Ok (Js.to_string el##.value)
     | Dom_html.Textarea el -> Ok (Js.to_string el##.value)
-    | Dom_html.Select el   -> Ok (Js.to_string el##.value)
+    | Dom_html.Select el -> Ok (Js.to_string el##.value)
     | _ -> Error "expected an input, textarea or select element"
   ;;
 
   let checked_value tagged_element =
     match tagged_element with
-    | Dom_html.Input el -> Ok (if Js.to_bool el##.checked then (Some el##.value) else None)
+    | Dom_html.Input el -> Ok (if Js.to_bool el##.checked then Some el##.value else None)
     | _ -> Error "expected input element"
   ;;
 
@@ -564,39 +592,39 @@ module State = struct
       |> Dom.list_of_nodeList
     in
     if List.is_empty radio_list
-    then (Error [Form_error.of_string ~id "no radio buttons found"])
-    else
-      (let selected_idxs =
-         List.filter_map radio_list
-           ~f:(fun el ->
-             match checked_value (Dom_html.tagged el) with
-             | Ok (Some v)       -> Some (Js.to_string v)
-             | Ok None | Error _ -> None)
-       in
-       match selected_idxs with
-       | [idx_str] -> Ok idx_str
-       | []        -> Error [Form_error.of_string ~id "not a single radio button is checked"]
-       | _         -> Error [Form_error.of_string ~id "multiple radio buttons are checked"]
-      )
+    then Error [ Form_error.of_string ~id "no radio buttons found" ]
+    else (
+      let selected_idxs =
+        List.filter_map radio_list ~f:(fun el ->
+          match checked_value (Dom_html.tagged el) with
+          | Ok (Some v) -> Some (Js.to_string v)
+          | Ok None
+          | Error _ -> None)
+      in
+      match selected_idxs with
+      | [ idx_str ] -> Ok idx_str
+      | [] -> Error [ Form_error.of_string ~id "not a single radio button is checked" ]
+      | _ -> Error [ Form_error.of_string ~id "multiple radio buttons are checked" ])
   ;;
 
-  let get_field : type a . a Field.t -> a Id.t -> (a, Form_error.t list) Result.t =
+  let get_field : type a. a Field.t -> a Id.t -> (a, Form_error.t list) Result.t =
     fun field id ->
       match field with
       | Field.Bool ->
         Result.map ~f:Option.is_some (get_with_tagged_element id ~f:checked_value)
-      | Field.String  ->
+      | Field.String ->
         let single_element_result = get_with_tagged_element id ~f:string_value in
         let radio_buttons_result = get_checked_radio_button id in
-        match single_element_result, radio_buttons_result with
-        | Ok x, Error _ | Error _, Ok x -> Ok x
-        | Error a, Error b -> Error (a @ b)
-        | Ok _select, Ok _radio -> Error [Form_error.of_string ~id "found multiple inputs"]
+        (match single_element_result, radio_buttons_result with
+         | Ok x, Error _
+         | Error _, Ok x -> Ok x
+         | Error a, Error b -> Error (a @ b)
+         | Ok _select, Ok _radio ->
+           Error [ Form_error.of_string ~id "found multiple inputs" ])
   ;;
 
-  let rec read_value' :
-    type g s ids. (g, s, ids) State.t -> List_states.t
-    -> (g, Form_error.t list) Result.t =
+  let rec read_value' : type g s ids.
+    (g, s, ids) State.t -> List_states.t -> (g, Form_error.t list) Result.t =
     fun t list_map ->
       match t with
       | Not_editable a -> Ok a
@@ -608,27 +636,32 @@ module State = struct
       | Map (inner, f) -> Result.map (read_value' inner list_map) ~f
       | Contra_map (inner, _) -> read_value' inner list_map
       | Map_ids (inner, _) -> read_value' inner list_map
-      | Conv { inner; to_outer; block_id; } ->
-        Result.bind (read_value' inner list_map)
-          ~f:(fun x -> to_outer x (field_ids' inner list_map) ~block_id)
+      | Conv { inner; to_outer; block_id } ->
+        Result.bind (read_value' inner list_map) ~f:(fun x ->
+          to_outer x (field_ids' inner list_map) ~block_id)
       | List witness ->
-        let (Of_list.Of_list list_state) = Map.find_exn list_map (Type_equal.Id.uid witness) in
+        let (Of_list.Of_list list_state) =
+          Map.find_exn list_map (Type_equal.Id.uid witness)
+        in
         let Type_equal.T = Type_equal.Id.same_witness_exn witness list_state.witness in
         let ok_list, err_list =
-          List.partition_map list_state.list
-            ~f:(fun x -> Result.ok_fst (read_value' (Identified.extract x) list_map))
+          List.partition_map list_state.list ~f:(fun x ->
+            Result.ok_fst (read_value' (Identified.extract x) list_map))
         in
-        match err_list with
-        | [] -> Ok ok_list
-        | errors -> Error (List.concat errors)
+        (match err_list with
+         | [] -> Ok ok_list
+         | errors -> Error (List.concat errors))
   ;;
 
   let check_uid_exn set id witness =
     if Id.Pack.Set.mem set id
     then ()
-    else (failwithf "Id %S does not belong to the form %S"
-            (Id.Pack.to_string id)
-            (Type_equal.Id.name witness) ())
+    else
+      failwithf
+        "Id %S does not belong to the form %S"
+        (Id.Pack.to_string id)
+        (Type_equal.Id.name witness)
+        ()
   ;;
 
   let read_value : type a ids. t -> (a, ids) form -> a option * t =
@@ -636,22 +669,21 @@ module State = struct
       let Type_equal.T = require_witness_matches_exn ~form t.witness in
       let value_option, errors =
         match read_value' (Identified.extract t.state) t.list_map with
-        | Error errors -> None      , errors
-        | Ok value     -> Some value, []
+        | Error errors -> None, errors
+        | Ok value -> Some value, []
       in
       let uid_error_alist =
-        List.map errors
-          ~f:(fun (Form_error.Pack (field_id, err)) ->
-            let pack = Id.pack field_id in
-            check_uid_exn t.uid_set pack form.witness;
-            pack, err)
+        List.map errors ~f:(fun (Form_error.Pack (field_id, err)) ->
+          let pack = Id.pack field_id in
+          check_uid_exn t.uid_set pack form.witness;
+          pack, err)
       in
       let errors =
         Id.Pack.Map.of_alist_multi uid_error_alist
         |> Id.Pack.Map.map ~f:(function
-          | []  -> assert false
-          | [e] -> e
-          | l   -> Error.of_list l)
+          | [] -> assert false
+          | [ e ] -> e
+          | l -> Error.of_list l)
       in
       value_option, Pack { t with errors }
   ;;
@@ -663,46 +695,44 @@ module State = struct
   ;;
 
   let errors (Pack t) = Map.data t.errors
-
 end
 
 (* Do not forget to always add the optional key,
    otherwise Incr_dom diff doesn't work properly. *)
 module Input = struct
-
   open Incr_dom.Vdom
 
   let field_pack (State.Pack state) id = Id.Pack.Map.find_exn state.fields (Id.pack id)
 
   let string_field state id : string option =
-    let Field.Pack (field, opt) = field_pack state id in
+    let (Field.Pack (field, opt)) = field_pack state id in
     match field with
-    | Field.String  -> opt
-    | Field.Bool    -> failwith "expected string field"
+    | Field.String -> opt
+    | Field.Bool -> failwith "expected string field"
   ;;
 
   let text state id attr =
     let value = Option.value ~default:"" (string_field state id) in
     let id = Id.to_string id in
-    Node.input ~key:id
-      ([Attr.type_ "text"; Attr.id id; Attr.value value] @ attr) []
+    Node.input ~key:id ([ Attr.type_ "text"; Attr.id id; Attr.value value ] @ attr) []
   ;;
 
   let bool_field state id : bool option =
-    let Field.Pack (field, opt) = field_pack state id in
+    let (Field.Pack (field, opt)) = field_pack state id in
     match field with
-    | Field.Bool    -> opt
-    | Field.String  -> failwith "expected bool field"
+    | Field.Bool -> opt
+    | Field.String -> failwith "expected bool field"
   ;;
 
   let checkbox state id attr =
     let value = bool_field state id in
     let id = Id.to_string id in
-    let attr = (Attr.type_ "checkbox") :: (Attr.id id) :: attr in
+    let attr = Attr.type_ "checkbox" :: Attr.id id :: attr in
     let attr =
       match value with
-      | Some true         ->  attr @ [Attr.checked]
-      | None | Some false ->  attr
+      | Some true -> attr @ [ Attr.checked ]
+      | None
+      | Some false -> attr
     in
     Node.input ~key:id attr []
   ;;
@@ -710,25 +740,25 @@ module Input = struct
   let textarea state id attr =
     let text = Option.value ~default:"" (string_field state id) in
     let id = Id.to_string id in
-    Node.textarea ~key:id
-      ((Attr.id id) :: attr) [Node.text text]
+    Node.textarea ~key:id (Attr.id id :: attr) [ Node.text text ]
   ;;
 
-  let radio_button state {Variant_id.options; field_id; _} attr =
+  let radio_button state { Variant_id.options; field_id; _ } attr =
     let selected_idx =
       Option.value_map ~default:0 ~f:Int.of_string (string_field state field_id)
     in
     let id = Id.to_string field_id in
     List.mapi (Array.to_list options) ~f:(fun idx opt ->
-      let selected_attr = if selected_idx = idx then [Attr.checked] else [] in
+      let selected_attr = if selected_idx = idx then [ Attr.checked ] else [] in
       let radio_attr =
-        [Attr.type_ "radio"; Attr.create "name" id; Attr.value (Int.to_string idx)]
+        [ Attr.type_ "radio"; Attr.create "name" id; Attr.value (Int.to_string idx) ]
       in
-      opt, Node.input ~key:(sprintf "%s-%d" id idx) (selected_attr @ radio_attr @ attr) []
-    )
+      ( opt
+      , Node.input ~key:(sprintf "%s-%d" id idx) (selected_attr @ radio_attr @ attr) []
+      ))
   ;;
 
-  let dropdown state {Variant_id.options; equal = _; field_id} attr ?compare to_string =
+  let dropdown state { Variant_id.options; equal = _; field_id } attr ?compare to_string =
     let selected_idx =
       Option.value_map ~default:0 ~f:Int.of_string (string_field state field_id)
     in
@@ -736,13 +766,10 @@ module Input = struct
     let select_options =
       List.mapi (Array.to_list options) ~f:(fun idx opt ->
         let selected_attr =
-          if selected_idx = idx
-          then [Attr.create "selected" "selected"]
-          else []
+          if selected_idx = idx then [ Attr.create "selected" "selected" ] else []
         in
-        let option_attr = selected_attr @ [Attr.value (Int.to_string idx)] in
-        opt, Node.option option_attr [Node.text (to_string opt)]
-      )
+        let option_attr = selected_attr @ [ Attr.value (Int.to_string idx) ] in
+        opt, Node.option option_attr [ Node.text (to_string opt) ])
     in
     let sorted_options =
       match compare with
@@ -751,7 +778,6 @@ module Input = struct
     in
     Node.select ~key:id (Attr.id id :: attr) (List.map sorted_options ~f:snd)
   ;;
-
 end
 
 module List = struct
@@ -759,24 +785,23 @@ module List = struct
   open State
 
   (* This is similar to [Either.t] but makes the code much easier to read. *)
-  type ('a,'b) old_or_new =
+  type ('a, 'b) old_or_new =
     | Old of 'a
     | New of 'b
 
-  type 's list_modifier = {
-    transform : 'elt. 'elt list -> create_new_form:(?init:'s -> unit -> 'elt) -> 'elt list
-  }
+  type 's list_modifier =
+    { transform :
+        'elt. 'elt list -> create_new_form:(?init:'s -> unit -> 'elt) -> 'elt list
+    }
 
   let check_uniqness list =
     let old_idx_set = Int.Hash_set.create () in
     let all_old_unique =
       List.for_all list ~f:(function
         | Old (_, idx) ->
-          begin
-            match Hash_set.strict_add old_idx_set idx with
-            | Ok ()   -> true
-            | Error _ -> false
-          end
+          (match Hash_set.strict_add old_idx_set idx with
+           | Ok () -> true
+           | Error _ -> false)
         | New _ -> true)
     in
     match all_old_unique with
@@ -784,12 +809,15 @@ module List = struct
     | false -> failwith "Duplicating existing elements of a list is not allowed"
   ;;
 
-  let modify_list' (type g s ids) list_map
+  let modify_list'
+        (type g s ids)
+        list_map
         ~(list_id : (g, s, ids) params Type_equal.Id.t)
         ~(f : s list_modifier)
     =
     let (Of_list.Of_list ({ el_desc; list; prefix; witness } as list_state)) =
-      Map.find_exn list_map (Type_equal.Id.uid list_id) in
+      Map.find_exn list_map (Type_equal.Id.uid list_id)
+    in
     let Type_equal.T = Type_equal.Id.same_witness_exn list_id witness in
     let new_list =
       let old_list = List.mapi list ~f:(fun i x -> Old (x, i)) in
@@ -799,64 +827,59 @@ module List = struct
     let remaining_indicies = check_uniqness new_list in
     let removed_keys =
       List.foldi list ~init:[] ~f:(fun i tail state ->
-        if not (Hash_set.mem remaining_indicies i) then
-          (collect_list_keys_in_use (Identified.extract state) ~list_map ~tail)
-        else
-          tail)
+        if not (Hash_set.mem remaining_indicies i)
+        then collect_list_keys_in_use (Identified.extract state) ~list_map ~tail
+        else tail)
     in
-    let cleared_list_map =
-      List.fold removed_keys ~init:list_map ~f:Map.remove
-    in
+    let cleared_list_map = List.fold removed_keys ~init:list_map ~f:Map.remove in
     let modified_list =
       List.map new_list ~f:(function
         | Old _ as x -> x
         | New init ->
-          let state, list_states = create' ~init ~prefix (Identified.extract el_desc) in
-          New (Identified.create state, list_states)
-      )
+          let state, list_states =
+            create' ~init ~prefix (Identified.extract el_desc)
+          in
+          New (Identified.create state, list_states))
     in
     let states =
-      List.map modified_list
-        ~f:(function Old (state,_) | New (state,_) -> state)
+      List.map modified_list ~f:(function Old (state, _) | New (state, _) -> state)
     in
     let list_map_to_add =
       List.filter_map modified_list ~f:(function
-        | Old _               -> None
-        | New (_,list_states) -> Some list_states)
+        | Old _ -> None
+        | New (_, list_states) -> Some list_states)
     in
     let list_states =
-      List.reduce_balanced ~f:merge_disjoint_maps_exn (cleared_list_map :: list_map_to_add)
+      List.reduce_balanced
+        ~f:merge_disjoint_maps_exn
+        (cleared_list_map :: list_map_to_add)
       |> Option.value ~default:Type_equal.Id.Uid.Map.empty
     in
-    Map.set list_states ~key:(Type_equal.Id.uid list_id) ~data:(
-      Of_list.Of_list { list_state with list = states })
+    Map.set
+      list_states
+      ~key:(Type_equal.Id.uid list_id)
+      ~data:(Of_list.Of_list { list_state with list = states })
   ;;
 
   let modify_list (Pack t) (List_id.List_id list_id) ~f =
     let list_map = modify_list' ~list_id ~f t.list_map in
     let uid_set = uid_set (Identified.extract t.state) list_map in
     let fields = fields (Identified.extract t.state) list_map in
-    Pack { t with uid_set; fields; list_map; }
+    Pack { t with uid_set; fields; list_map }
   ;;
 
   let cons t ?init list_id =
-    let transform =
-      fun list ~create_new_form -> create_new_form ?init () :: list
-    in
+    let transform list ~create_new_form = create_new_form ?init () :: list in
     modify_list t list_id ~f:{ transform }
   ;;
 
   let append t ?init list_id =
-    let transform =
-      fun list ~create_new_form -> list @ [create_new_form ?init ()]
-    in
+    let transform list ~create_new_form = list @ [ create_new_form ?init () ] in
     modify_list t list_id ~f:{ transform }
   ;;
 
   let remove_nth t list_id n =
-    let transform =
-      fun list ~create_new_form:_ -> List.filteri list ~f:(fun i _ -> i <> n)
-    in
+    let transform list ~create_new_form:_ = List.filteri list ~f:(fun i _ -> i <> n) in
     modify_list t list_id ~f:{ transform }
   ;;
 end

--- a/src/form.mli
+++ b/src/form.mli
@@ -263,4 +263,8 @@ module Input : sig
     -> ?compare:('a -> 'a -> int)
     -> ('a -> string)
     -> Node.t
+
+  (** Wrapper for {!Vdom.Node.label} and {!Vdom.Attr.for_} *)
+  val label : 'a Id.t -> Attr.t list -> Node.t list -> Node.t
+
 end

--- a/src/form.mli
+++ b/src/form.mli
@@ -1,5 +1,5 @@
-open Core_kernel
 (** Module for creating and manipulating web forms. *)
+open Core_kernel
 
 (** {1 Typed Id} *)
 
@@ -38,7 +38,6 @@ end
     (like bool or string fields) and combining them into more complex
     structures which can be themselves combined with other structures. *)
 module Description : sig
-
   (** Describes how to edit a type as a series of form elements.
 
       The two type parameters ['s] and ['g] represent respectively
@@ -52,17 +51,15 @@ module Description : sig
   type ('g, 's, 'ids) t
 
   val not_editable : default:'a -> ('a, 'a, unit) t
-
   val bool : (bool, bool, bool Id.t) t
   val string : (string, string, string Id.t) t
-
   val sexp : of_sexp:(Sexp.t -> 'a) -> sexp_of:('a -> Sexp.t) -> ('a, 'a, string Id.t) t
 
   (** Raises an exception if the provided list is empty or contains duplicate values. *)
   val variant : 'a list -> equal:('a -> 'a -> bool) -> ('a, 'a, 'a Variant_id.t) t
 
   (** Combine two [t]'s. *)
-  val both : ('a, 's, 'a_ids) t -> ('b, 's, 'b_ids) t -> ('a * 'b , 's, 'a_ids * 'b_ids) t
+  val both : ('a, 's, 'a_ids) t -> ('b, 's, 'b_ids) t -> ('a * 'b, 's, 'a_ids * 'b_ids) t
 
   val map : ('a, 's, 'ids) t -> f:('a -> 'b) -> ('b, 's, 'ids) t
   val contra_map : ('g, 'b, 'ids) t -> f:('a -> 'b) -> ('g, 'a, 'ids) t
@@ -78,25 +75,23 @@ module Description : sig
     -> f:('a -> 'ids -> ('b, Form_error.t list) Result.t)
     -> ('b, 's, 'ids) t
 
-  val list :
-    ('g, 's, 'ids) t -> ('g list, 's list, 'ids list * 's List_id.t) t
+  val list : ('g, 's, 'ids) t -> ('g list, 's list, 'ids list * 's List_id.t) t
 
   module Let_syntax : sig
     module Let_syntax : sig
       val map : ('a, 's, 'ids) t -> f:('a -> 'b) -> ('b, 's, 'ids) t
-      val both : ('a, 's, 'a_id) t -> ('b, 's, 'b_id) t -> ('a * 'b , 's, 'a_id * 'b_id) t
+      val both : ('a, 's, 'a_id) t -> ('b, 's, 'b_id) t -> ('a * 'b, 's, 'a_id * 'b_id) t
 
       module Open_on_rhs : sig
         (** Infix alias for [map]. *)
-        val (^<) : ('a -> 'b) -> ('a, 's, 'ids) t -> ('b, 's, 'ids) t
+        val ( ^< ) : ('a -> 'b) -> ('a, 's, 'ids) t -> ('b, 's, 'ids) t
 
         (** Infix alias for [contra_map]. *)
-        val (<^) : ('g, 'b, 'ids) t -> ('a -> 'b) -> ('g, 'a, 'ids) t
+        val ( <^ ) : ('g, 'b, 'ids) t -> ('a -> 'b) -> ('g, 'a, 'ids) t
 
         val bool : (bool, bool, bool Id.t) t
         val string : (string, string, string Id.t) t
-        val list :
-          ('g, 's, 'ids) t -> ('g list, 's list, 'ids list * 's List_id.t) t
+        val list : ('g, 's, 'ids) t -> ('g list, 's list, 'ids list * 's List_id.t) t
         val variant : 'a list -> equal:('a -> 'a -> bool) -> ('a, 'a, 'a Variant_id.t) t
       end
     end
@@ -139,29 +134,38 @@ module Description : sig
 
       type ('field, 'head, 'head_ids, 'tail, 'tail_ids, 'all_fields, 'all_ids, 'record) fold_step =
         ('head, 'head_ids, 'all_fields, 'all_ids, 'record) accum
-        -> ('all_fields -> 'field) * ('tail, 'tail_ids, 'all_fields, 'all_ids, 'record) accum
+        -> ('all_fields -> 'field)
+           * ('tail, 'tail_ids, 'all_fields, 'all_ids, 'record) accum
 
       type ('field, 'field_ids, 'tail, 'tail_ids, 'all_fields, 'all_ids, 'record) handle_one_field =
         ( 'field
-        , ('field, 'tail) Record_builder.Hlist.cons, ('field_ids, 'tail_ids) Record_builder.Hlist.cons
-        , 'tail, 'tail_ids
-        , 'all_fields Record_builder.Hlist.nonempty, 'all_ids Record_builder.Hlist.nonempty
-        , 'record
-        ) fold_step
+        , ('field, 'tail) Record_builder.Hlist.cons
+        , ('field_ids, 'tail_ids) Record_builder.Hlist.cons
+        , 'tail
+        , 'tail_ids
+        , 'all_fields Record_builder.Hlist.nonempty
+        , 'all_ids Record_builder.Hlist.nonempty
+        , 'record )
+          fold_step
 
       type ('all_fields, 'all_ids, 'record) handle_all_fields =
         ( 'record
-        , 'all_fields Record_builder.Hlist.nonempty, 'all_ids Record_builder.Hlist.nonempty
-        , Record_builder.Hlist.nil, Record_builder.Hlist.nil
-        , 'all_fields Record_builder.Hlist.nonempty, 'all_ids Record_builder.Hlist.nonempty
-        , 'record) fold_step
+        , 'all_fields Record_builder.Hlist.nonempty
+        , 'all_ids Record_builder.Hlist.nonempty
+        , Record_builder.Hlist.nil
+        , Record_builder.Hlist.nil
+        , 'all_fields Record_builder.Hlist.nonempty
+        , 'all_ids Record_builder.Hlist.nonempty
+        , 'record )
+          fold_step
     end
 
     (** Handle one field of a record using the supplied editor.
 
         This should be used as an argument to [Fields.make_creator], see the example.
     *)
-    val field : ('field, 'field, 'field_ids) t
+    val field
+      :  ('field, 'field, 'field_ids) t
       -> ('record, 'field) Field.t
       -> ('field, 'field_ids, _, _, _, _, 'record) Make_creator_types.handle_one_field
 
@@ -170,7 +174,7 @@ module Description : sig
         This is used with an application of [Fields.make_creator] as shown in the example.
     *)
     val build_for_record
-      : (_, 'ids, 'record) Make_creator_types.handle_all_fields
+      :  (_, 'ids, 'record) Make_creator_types.handle_all_fields
       -> ('record, 'record, 'ids) t
   end
 end
@@ -210,17 +214,16 @@ module State : sig
 
   (** Return all errors associated with the form state *)
   val errors : t -> Error.t list
-
 end
 
 (** {1 List module} *)
 
 (** Provides operations related to lists of forms. *)
 module List : sig
-
-  type 'a list_modifier = {
-    transform : 'elt. 'elt list -> create_new_form:(?init:'a -> unit -> 'elt) -> 'elt list
-  }
+  type 'a list_modifier =
+    { transform :
+        'elt. 'elt list -> create_new_form:(?init:'a -> unit -> 'elt) -> 'elt list
+    }
 
   (** Modify list with a supplied [list_modifier] function.
 
@@ -229,7 +232,7 @@ module List : sig
   val modify_list : State.t -> 'a List_id.t -> f:'a list_modifier -> State.t
 
   (** Add one empty form in front of the list *)
-  val cons   : State.t -> ?init:'a -> 'a List_id.t -> State.t
+  val cons : State.t -> ?init:'a -> 'a List_id.t -> State.t
 
   (** Add one empty form to the end of the list. *)
   val append : State.t -> ?init:'a -> 'a List_id.t -> State.t
@@ -238,32 +241,26 @@ module List : sig
       If [int] is invalid index (i.e. [int] < 0 or [int] >= length of the
       list), the list remains unchanged and no exceptions are raised. *)
   val remove_nth : State.t -> 'a List_id.t -> int -> State.t
-
 end
 
 (** {1 Input module} *)
 
 (** Wrappers to create VDom input fields using field ids. *)
 module Input : sig
-
   open Incr_dom.Vdom
 
-  val text     : State.t -> string    Id.t -> Attr.t list -> Node.t
-
-  val textarea : State.t -> string    Id.t -> Attr.t list -> Node.t
-
-  val checkbox : State.t -> bool      Id.t -> Attr.t list -> Node.t
-
+  val text : State.t -> string Id.t -> Attr.t list -> Node.t
+  val textarea : State.t -> string Id.t -> Attr.t list -> Node.t
+  val checkbox : State.t -> bool Id.t -> Attr.t list -> Node.t
   val radio_button : State.t -> 'a Variant_id.t -> Attr.t list -> ('a * Node.t) list
 
   (** Dropdown for all initially provided values optionally sorted using the provided
       compare function.  *)
   val dropdown
-    : State.t
+    :  State.t
     -> 'a Variant_id.t
     -> Attr.t list
     -> ?compare:('a -> 'a -> int)
     -> ('a -> string)
     -> Node.t
-
 end

--- a/src/incr_dom_widgets.ml
+++ b/src/incr_dom_widgets.ml
@@ -1,5 +1,9 @@
 
-module Css_gen                         = Css_gen
-module Interactive                     = Interactive
-module Form                            = Form
-module Sexp_form                       = Sexp_form
+open! Core_kernel
+module Css_gen = Css_gen
+module Interactive = Interactive
+module Form = Form
+module Sexp_form = Sexp_form
+module Spinner = Spinner
+module Modal = Modal
+module Buttons = Buttons

--- a/src/interactive.mli
+++ b/src/interactive.mli
@@ -100,6 +100,7 @@ open Vdom
 type 'a t
 
 (* Let syntax is defined at the end of this file. *)
+
 include Monad.S_without_syntax with type 'a t := 'a t
 
 module Primitives : sig
@@ -108,19 +109,10 @@ module Primitives : sig
       create two nodes with the same id), but it might be useful
       if you want to refer to the node elsewhere.
   *)
-  type 'a primitive =
-    ?attrs:Attr.t list
-    -> ?id:string
-    -> unit
-    -> 'a t
+  type 'a primitive = ?attrs:Attr.t list -> ?id:string -> unit -> 'a t
 
-  val text
-    :  ?init:string
-    -> string primitive
-
-  val text_area
-    :  ?init:string
-    -> string primitive
+  val text : ?init:string -> string primitive
+  val text_area : ?init:string -> string primitive
 
   module Button_state : sig
     type t =
@@ -128,13 +120,8 @@ module Primitives : sig
       | Not_pressed
   end
 
-  val button
-    :  text:string
-    -> Button_state.t primitive
-
-  val disabled_button
-    :  text:string
-    -> unit primitive
+  val button : text:string -> Button_state.t primitive
+  val disabled_button : text:string -> unit primitive
 
   (** [options] is a list of tuples (label, value). [label] is what will be
       displayed to the user in the dropdown. [value] is what will be produced
@@ -145,10 +132,7 @@ module Primitives : sig
 
       Raises when [options] is empty or [init >= List.length options].
   *)
-  val dropdown_exn
-    :  options:(string * 'a) list
-    -> ?init:int
-    -> 'a primitive
+  val dropdown_exn : options:(string * 'a) list -> ?init:int -> 'a primitive
 
   (** [dropdown_with_blank_exn] is a wrapper around [dropdown_exn] which adds a blank
       option to the dropdown that produces [None]. It is otherwise the same as
@@ -164,18 +148,9 @@ module Primitives : sig
     -> ?init:int
     -> 'a option primitive
 
-  val checkbox
-    :  ?init:bool
-    -> bool primitive
-
-  val nodes
-    :  Node.t list
-    -> unit t
-
-  val message
-    :  string
-    -> unit t
-
+  val checkbox : ?init:bool -> bool primitive
+  val nodes : Node.t list -> unit t
+  val message : string -> unit t
   val line_break : unit t
 
   (** [create] allows you to create your own primitives.
@@ -206,19 +181,18 @@ module Primitives : sig
       For an example, check the implementation of [Primitives.text].
   *)
   val create
-    :  init   : 'a
-    -> render : (inject : ('a -> Event.t) -> value : 'a Incr.t -> Node.t list Incr.t)
+    :  init:'a
+    -> render:(inject:('a -> Event.t) -> value:'a Incr.t -> Node.t list Incr.t)
     -> 'a t
 
-  val default_text_attrs      : Attr.t list
+  val default_text_attrs : Attr.t list
   val default_text_area_attrs : Attr.t list
-  val default_button_attrs    : Attr.t list
-  val default_dropdown_attrs  : Attr.t list
-
-  val bootstrap_text_attrs      : Attr.t list
+  val default_button_attrs : Attr.t list
+  val default_dropdown_attrs : Attr.t list
+  val bootstrap_text_attrs : Attr.t list
   val bootstrap_text_area_attrs : Attr.t list
-  val bootstrap_button_attrs    : Attr.t list
-  val bootstrap_dropdown_attrs  : Attr.t list
+  val bootstrap_button_attrs : Attr.t list
+  val bootstrap_dropdown_attrs : Attr.t list
 end
 
 (** You have to schedule an action whenever the state changes in order for the view to
@@ -229,8 +203,8 @@ end
 *)
 val render
   :  'a t
-  -> on_input : ('a -> 'action)
-  -> inject   : ('action -> Event.t)
+  -> on_input:('a -> 'action)
+  -> inject:('action -> Event.t)
   -> Node.t Incr.t
 
 (** [map_nodes] can be used to change the presentation of the [Interactive.t].
@@ -241,10 +215,7 @@ val render
         Node.div [Attr.style ["background", "red"]] nodes)
     ]}
 *)
-val map_nodes
-  :  'a t
-  -> f:(Node.t list -> Node.t list)
-  -> 'a t
+val map_nodes : 'a t -> f:(Node.t list -> Node.t list) -> 'a t
 
 (** [map_nodes_value_dependent] is like [map_nodes], but the function can also depend on
     the current value of the [Interactive.t].
@@ -252,36 +223,28 @@ val map_nodes
     For example, in a ['a Or_error.t Interactive.t], you could use this to add a node
     which displays the error.
 *)
-val map_nodes_value_dependent
-  :  'a t
-  -> f:('a -> Node.t list -> Node.t list)
-  -> 'a t
+val map_nodes_value_dependent : 'a t -> f:('a -> Node.t list -> Node.t list) -> 'a t
 
-val wrap_in_div
-  :  ?attrs: Attr.t list
-  -> 'a t
-  -> 'a t
-
-val of_incr
-  :  'a Incr.t
-  -> 'a t
+val wrap_in_div : ?attrs:Attr.t list -> 'a t -> 'a t
+val of_incr : 'a Incr.t -> 'a t
 
 (** [current_value] calls [Incr.stabilize].
 
     See also [render], which is the typical way of handling changes to the value.
 *)
-val current_value
-  :  'a t
-  -> 'a
+val current_value : 'a t -> 'a
 
 module Let_syntax : sig
   val return : 'a -> 'a t
+
   include Monad.Infix with type 'a t := 'a t
+
   module Let_syntax : sig
     val return : 'a -> 'a t
     val bind : 'a t -> f:('a -> 'b t) -> 'b t
     val map : 'a t -> f:('a -> 'b) -> 'b t
     val both : 'a t -> 'b t -> ('a * 'b) t
+
     module Open_on_rhs = Primitives
   end
 end

--- a/src/modal.ml
+++ b/src/modal.ml
@@ -1,0 +1,22 @@
+open! Core_kernel
+open Incr_dom.Vdom
+
+let modal ~on_close ~modal_body =
+  Node.div
+    [ Attr.classes [ "modal-overlay"; "active" ] ]
+    [ Node.div
+        [ Attr.class_ "modal-container" ]
+        [ Node.div
+            [ Attr.class_ "modal-header" ]
+            [ Node.div
+                [ Attr.classes [ "clickable"; "modal-close" ]
+                ; Attr.on_click (fun ev -> on_close ev)
+                ]
+                [ Node.span [] [ Node.text "X" ] ]
+            ]
+        ; Node.div
+            [ Attr.class_ "modal-body" ]
+            [ Node.div [ Attr.class_ "center" ] [ modal_body ] ]
+        ]
+    ]
+;;

--- a/src/modal.mli
+++ b/src/modal.mli
@@ -1,0 +1,6 @@
+open Incr_dom.Vdom
+
+val modal
+  :  on_close:(Js_of_ocaml.Dom_html.mouseEvent Js_of_ocaml.Js.t -> Event.t)
+  -> modal_body:Node.t
+  -> Node.t

--- a/src/sexp_form.ml
+++ b/src/sexp_form.ml
@@ -11,65 +11,43 @@ module Parse_state = struct
      because it needs to be passed to each node on creation. *)
   type t =
     { indentation : int
-    ; default     : Sexp.t list option
+    ; default : Sexp.t list option
     }
   [@@deriving fields, sexp]
 
-  let create ~default () =
-    { indentation = 0
-    ; default
-    }
-  ;;
-
-  let indent t =
-    { t with indentation = t.indentation + 1 }
-  ;;
-
-  let map_default t ~f =
-    { t with default = Option.map t.default ~f }
-  ;;
-
-  let has_default t = Option.is_some t.default ;;
-
-  let erase_default t =
-    { t with default = None }
-  ;;
+  let create ~default () = { indentation = 0; default }
+  let indent t = { t with indentation = t.indentation + 1 }
+  let map_default t ~f = { t with default = Option.map t.default ~f }
+  let has_default t = Option.is_some t.default
+  let erase_default t = { t with default = None }
 
   let require_empty t =
     match t.default with
     | None
     | Some [] -> ()
-    | Some sexps ->
-      raise_s [%message "Expected ')' but found"
-                          (sexps : Sexp.t list)]
+    | Some sexps -> raise_s [%message "Expected ')' but found" (sexps : Sexp.t list)]
   ;;
 
   let transform_first_sexp t ~f =
     map_default t ~f:(function
       | [] -> failwith "Unexpected ')'"
-      | x :: xs -> f x :: xs
-    )
+      | x :: xs -> f x :: xs)
   ;;
 
   let consume t expected =
     let default =
       match t.default with
       | None -> None
-      | Some (x :: xs) when Sexp.equal x expected -> Some xs
+      | Some (x :: xs)
+        when Sexp.equal x expected -> Some xs
       | Some (found :: _) ->
-        raise_s [%message "Parse failure"
-                            (expected : Sexp.t)
-                            (found : Sexp.t)]
-      | Some [] ->
-        raise_s [%message "Unexpected ')'"
-                            (expected : Sexp.t)]
+        raise_s [%message "Parse failure" (expected : Sexp.t) (found : Sexp.t)]
+      | Some [] -> raise_s [%message "Unexpected ')'" (expected : Sexp.t)]
     in
     { t with default }
   ;;
 
-  let with_default t default =
-    { t with default = Some default }
-  ;;
+  let with_default t default = { t with default = Some default }
 end
 
 module Init_result = struct
@@ -87,22 +65,25 @@ type 'a t = Parse_state.t -> 'a Init_result.t
    monospaced font).
 *)
 
-let default_editor_message_style_term = Css_gen.font_family ["Arial"]
+let default_editor_message_style_term = Css_gen.font_family [ "Arial" ]
 let default_editor_message_attr = Attr.style default_editor_message_style_term
+
 let error_attr =
-  Attr.style Css_gen.(background_color (`Name "#FFCCCC") @> default_editor_message_style_term)
+  Attr.style
+    Css_gen.(background_color (`Name "#FFCCCC") @> default_editor_message_style_term)
+;;
 
 module Init = struct
   type 'a t =
     | Simple
     | With_default of
-        { default   : 'a
+        { default : 'a
         ; sexp_of_t : 'a -> Sexp.t
-        ; between   : Node.t option
-        ; diff      : original:Sexp.t -> updated:Sexp.t -> Node.t
+        ; between : Node.t option
+        ; diff : original:Sexp.t -> updated:Sexp.t -> Node.t
         }
 
-  let simple = Simple ;;
+  let simple = Simple
 
   let default = function
     | Simple -> None
@@ -114,9 +95,7 @@ module Init = struct
     With_default { default; between; sexp_of_t; diff }
   ;;
 
-  let no_diff ~original:(_ : Sexp.t) ~updated:(_ : Sexp.t) =
-    Node.text ""
-  ;;
+  let no_diff ~original:(_ : Sexp.t) ~updated:(_ : Sexp.t) = Node.text ""
 
   let node_after ~value t =
     match t with
@@ -134,135 +113,118 @@ module Init = struct
           diff ~original ~updated
       in
       let between_node = Option.value between ~default:(Node.div [] []) in
-      Node.div
-        [ Attr.style Css_gen.(text_align `Center) ]
-        [ between_node; diff_node ]
+      Node.div [ Attr.style Css_gen.(text_align `Center) ] [ between_node; diff_node ]
   ;;
-
 end
 
 let to_interactive ~init t =
   let default = Init.default init in
   let parse_state = Parse_state.create ~default () in
-  let { Init_result. form; parse_state } = t parse_state in
+  let { Init_result.form; parse_state } = t parse_state in
   let () = Parse_state.require_empty parse_state in
   Interactive.map_nodes_value_dependent form ~f:(fun value nodes ->
-    [ Node.create "pre" [] nodes; Init.node_after ~value init ]
-  )
+    [ Node.create "pre" [] nodes; Init.node_after ~value init ])
 ;;
 
 module T = struct
-  include Applicative.Make(struct
+  include Applicative.Make (struct
       type nonrec 'a t = 'a t
 
-      let return x =
-        fun parse_state ->
-          let form = x |> Or_error.return |> Interactive.return in
-          Init_result.Fields.create ~parse_state ~form
+      let return x parse_state =
+        let form = x |> Or_error.return |> Interactive.return in
+        Init_result.Fields.create ~parse_state ~form
       ;;
 
-      let map t ~f =
-        fun parse_state ->
-          let { Init_result. parse_state; form } = t parse_state in
-          let form = Interactive.map form ~f:(fun x -> Or_error.map x ~f) in
-          Init_result.Fields.create ~parse_state ~form
+      let map t ~f parse_state =
+        let { Init_result.parse_state; form } = t parse_state in
+        let form = Interactive.map form ~f:(fun x -> Or_error.map x ~f) in
+        Init_result.Fields.create ~parse_state ~form
       ;;
 
-      let map = `Custom map ;;
+      let map = `Custom map
 
-      let apply t1 t2 =
-        fun parse_state ->
-          let open Interactive.Let_syntax in
-          let { Init_result. parse_state; form = form1 } = t1 parse_state in
-          let { Init_result. parse_state; form = form2 } = t2 parse_state in
-          let form =
-            let%map a1 = form1
-            and a2 = form2
-            in
-            Or_error.map2 a1 a2 ~f:Fn.id
-          in
-          Init_result.Fields.create ~parse_state ~form
+      let apply t1 t2 parse_state =
+        let open Interactive.Let_syntax in
+        let { Init_result.parse_state; form = form1 } = t1 parse_state in
+        let { Init_result.parse_state; form = form2 } = t2 parse_state in
+        let form =
+          let%map a1 = form1
+          and a2 = form2 in
+          Or_error.map2 a1 a2 ~f:Fn.id
+        in
+        Init_result.Fields.create ~parse_state ~form
+      ;;
     end)
 end
 
 include T
 
-let ok form =
-  Interactive.map form ~f:(fun () -> Ok ())
+let ok form = Interactive.map form ~f:(fun () -> Ok ())
+
+let const_form form parse_state =
+  let form = ok form in
+  Init_result.Fields.create ~parse_state ~form
 ;;
 
-let const_form form =
-  fun parse_state ->
-    let form = ok form in
-    Init_result.Fields.create ~parse_state ~form
-;;
-
-let space = const_form (Interactive.Primitives.message " ") ;;
+let space = const_form (Interactive.Primitives.message " ")
 
 let handle_error_interactive where interactive =
   let interactive =
-    Interactive.map_nodes_value_dependent interactive
-      ~f:(fun value nodes ->
-        match value with
-        | Error _
-        | Ok (Ok _)      -> nodes
-        | Ok (Error err) ->
-          let error_message_node = Node.text (Error.to_string_hum err) in
-          let error_node = Node.span [ error_attr ] [ error_message_node ] in
-          let space_node = Node.text " " in
-          match where with
-          | `Before -> error_node :: space_node :: nodes
-          | `After  -> nodes @ [ space_node; error_node ]
-      )
+    Interactive.map_nodes_value_dependent interactive ~f:(fun value nodes ->
+      match value with
+      | Error _
+      | Ok (Ok _) -> nodes
+      | Ok (Error err) ->
+        let error_message_node = Node.text (Error.to_string_hum err) in
+        let error_node = Node.span [ error_attr ] [ error_message_node ] in
+        let space_node = Node.text " " in
+        (match where with
+         | `Before -> error_node :: space_node :: nodes
+         | `After -> nodes @ [ space_node; error_node ]))
   in
   Interactive.map interactive ~f:Or_error.join
 ;;
 
-let handle_error ~where t =
-  fun parse_state ->
-    let { Init_result. parse_state; form } = t parse_state in
-    let form = handle_error_interactive where form in
-    Init_result.Fields.create ~parse_state ~form
+let handle_error ~where t parse_state =
+  let { Init_result.parse_state; form } = t parse_state in
+  let form = handle_error_interactive where form in
+  Init_result.Fields.create ~parse_state ~form
 ;;
 
 let validate ~where t ~f =
-  map t ~f:(fun x -> Or_error.map (f x) ~f:(fun () -> x))
-  |> handle_error ~where
+  map t ~f:(fun x -> Or_error.map (f x) ~f:(fun () -> x)) |> handle_error ~where
 ;;
 
 let validate_interactive ~where t interactive ~f =
   let open Interactive.Let_syntax in
   (fun parse_state ->
-     let { Init_result. parse_state; form } = t parse_state in
+     let { Init_result.parse_state; form } = t parse_state in
      let form =
        let%map a = form
-       and b = interactive
-       in
+       and b = interactive in
        Or_error.map a ~f:(fun a -> Or_error.map (f a b) ~f:(fun () -> a))
      in
-     Init_result.Fields.create ~parse_state ~form
-  )
+     Init_result.Fields.create ~parse_state ~form)
   |> handle_error ~where
 ;;
 
 module Case = struct
   type 'a sexp_form = 'a t
+
   type 'a t =
-    { name : string
+    { name :
+        string
     (* [has_been_applied] is used to determine whether the value should be wrapped in
        parentheses when converted to a sexp. For instance, [A] is converted as [A] but
        [B of int] is converted as [(B 123)]. *)
     ; has_been_applied : bool
     ; inner : 'a sexp_form
-    } [@@deriving fields]
+    }
+  [@@deriving fields]
 
   let apply t sexp_form =
     let { name; has_been_applied; inner } = t in
-    let inner =
-      if has_been_applied
-      then (inner <* space)
-      else (inner)
-    in
+    let inner = if has_been_applied then inner <* space else inner in
     let inner = inner <*> sexp_form in
     Fields.create ~name ~inner ~has_been_applied:true
   ;;
@@ -273,17 +235,10 @@ module Case = struct
     Fields.create ~name ~inner ~has_been_applied
   ;;
 
-  let map t ~f =
-    { t with inner = T.map t.inner ~f }
-  ;;
+  let map t ~f = { t with inner = T.map t.inner ~f }
 
   let of_variant v =
-    let { Variantslib.Variant.
-          name
-        ; constructor
-        ; rank = _
-        } = v
-    in
+    let { Variantslib.Variant.name; constructor; rank = _ } = v in
     of_raw_parts ~name ~constructor
   ;;
 end
@@ -291,17 +246,16 @@ end
 module Record_field = struct
   type nonrec ('record, 'a) t = 'a t
 end
+
 module Record_builder = struct
   type nonrec ('record, 'a) t = 'a t
 end
 
 module Primitives = struct
-
-  let const sexp =
-    fun parse_state ->
-      let form = Interactive.Primitives.message (Sexp.to_string_hum sexp) |> ok in
-      let parse_state = Parse_state.consume parse_state sexp in
-      Init_result.Fields.create ~parse_state ~form
+  let const sexp parse_state =
+    let form = Interactive.Primitives.message (Sexp.to_string_hum sexp) |> ok in
+    let parse_state = Parse_state.consume parse_state sexp in
+    Init_result.Fields.create ~parse_state ~form
   ;;
 
   let const_atom s = const (Sexp.Atom s)
@@ -318,14 +272,13 @@ module Primitives = struct
            Option.map width ~f:(fun width -> Attr.create "size" (Int.to_string width))
          in
          let attrs =
-           List.filter_opt [  width_attr; placeholder_attr ]
+           List.filter_opt [ width_attr; placeholder_attr ]
            @ Interactive.Primitives.default_text_attrs
          in
          let%map_open user_text = text ~attrs ?init:initial_value () in
          Ok (parse user_text)
        in
-       Init_result.Fields.create ~parse_state ~form
-    )
+       Init_result.Fields.create ~parse_state ~form)
     |> handle_error ~where:`After
   ;;
 
@@ -334,8 +287,8 @@ module Primitives = struct
       let raise_exn ~reason =
         let msg =
           sprintf
-            "Expected a non-empty list of sexps with an atom as the first element \
-             when parsing the initial value, but %s"
+            "Expected a non-empty list of sexps with an atom as the first element when \
+             parsing the initial value, but %s"
             reason
         in
         raise_s [%message msg (parse_state : Parse_state.t)]
@@ -345,9 +298,12 @@ module Primitives = struct
       | Some (Sexp.Atom atom :: rest) ->
         Some atom, Parse_state.with_default parse_state rest
       | Some (Sexp.List _ :: _) -> raise_exn ~reason:"the first element was a list"
-      | Some []                 -> raise_exn ~reason:"the list was empty"
+      | Some [] -> raise_exn ~reason:"the list was empty"
     in
-    text_internal ?placeholder ?width ~parse_state_to_interactive_initial_value
+    text_internal
+      ?placeholder
+      ?width
+      ~parse_state_to_interactive_initial_value
       Or_error.return
   ;;
 
@@ -358,10 +314,11 @@ module Primitives = struct
       | Some (sexp :: rest) ->
         Some (Sexp.to_string_hum sexp), Parse_state.with_default parse_state rest
       | Some [] ->
-        raise_s [%message
-          "Expected a non-empty list of sexps when parsing the initial value, \
-           but the list was empty"
-            (parse_state : Parse_state.t)]
+        raise_s
+          [%message
+            "Expected a non-empty list of sexps when parsing the initial value, but the \
+             list was empty"
+              (parse_state : Parse_state.t)]
     in
     text_internal ~parse_state_to_interactive_initial_value (fun x ->
       Or_error.try_with (fun () -> text_to_sexp x)
@@ -374,63 +331,59 @@ module Primitives = struct
     |> handle_error ~where:`After
   ;;
 
-  let from_ppx_sexp ~t_of_sexp ?(on_error=Fn.id) () =
+  let from_ppx_sexp ~t_of_sexp ?(on_error = Fn.id) () =
     let text_to_sexp text =
-      if not (String.contains text '(' ||
-              String.contains text ')' ||
-              String.contains text '"')
-      then (Sexp.Atom text)
-      else (Sexp.of_string text)
+      if not
+           (String.contains text '('
+            || String.contains text ')'
+            || String.contains text '"')
+      then Sexp.Atom text
+      else Sexp.of_string text
     in
     sexp ~override_error:on_error () ~text_to_sexp
     |> map ~f:(fun s ->
-      Or_error.try_with (fun () -> t_of_sexp s)
-      |> Result.map_error ~f:on_error
-    )
+      Or_error.try_with (fun () -> t_of_sexp s) |> Result.map_error ~f:on_error)
     |> handle_error ~where:`After
   ;;
 
   let int =
     map (string ~width:10 ()) ~f:(fun x ->
       Or_error.try_with (fun () -> Int.of_string x)
-      |> Result.map_error ~f:(fun _ -> Error.of_string "This should be an integer.")
-    )
+      |> Result.map_error ~f:(fun _ -> Error.of_string "This should be an integer."))
     |> handle_error ~where:`After
   ;;
 
-  let enclose t =
-    fun parse_state ->
-      let { Parse_state. indentation; default } = parse_state in
-      let left_default, right_default =
-        match default with
-        | Some (Sexp.List xs :: rest) -> Some xs, Some rest
-        | None -> None, None
-        | Some (Sexp.Atom atom :: _) ->
-          raise_s [%message "Expected '(', found an atom" (atom : string)]
-        | Some [] -> failwith "Expected '(', found ')'"
-      in
-      let left_parse_state =
-        Parse_state.Fields.create ~indentation:(indentation + 1) ~default:left_default
-      in
-      let right_parse_state =
-        Parse_state.Fields.create ~indentation ~default:right_default
-      in
-      let { Init_result. parse_state = left_result; form } = t left_parse_state in
-      let () = Parse_state.require_empty left_result in
-      let open Interactive.Let_syntax in
-      let form =
-        let%map_open () = message "("
-        and value = form
-        and () = message ")"
-        in
-        value
-      in
-      Init_result.Fields.create ~form ~parse_state:right_parse_state
+  let enclose t parse_state =
+    let { Parse_state.indentation; default } = parse_state in
+    let left_default, right_default =
+      match default with
+      | Some (Sexp.List xs :: rest) -> Some xs, Some rest
+      | None -> None, None
+      | Some (Sexp.Atom atom :: _) ->
+        raise_s [%message "Expected '(', found an atom" (atom : string)]
+      | Some [] -> failwith "Expected '(', found ')'"
+    in
+    let left_parse_state =
+      Parse_state.Fields.create ~indentation:(indentation + 1) ~default:left_default
+    in
+    let right_parse_state =
+      Parse_state.Fields.create ~indentation ~default:right_default
+    in
+    let { Init_result.parse_state = left_result; form } = t left_parse_state in
+    let () = Parse_state.require_empty left_result in
+    let open Interactive.Let_syntax in
+    let form =
+      let%map_open () = message "("
+      and value = form
+      and () = message ")" in
+      value
+    in
+    Init_result.Fields.create ~form ~parse_state:right_parse_state
   ;;
 
   let newline_nodes parse_state =
     let spaces = String.make (Parse_state.indentation parse_state) ' ' in
-    [ Node.div [] [] ; Node.text spaces ]
+    [ Node.div [] []; Node.text spaces ]
   ;;
 
   let newline : unit t =
@@ -443,53 +396,44 @@ module Primitives = struct
   ;;
 
   let on_new_line t = newline *> t
-
-  let case_on_new_line (case : 'a Case.t) =
-    { case with inner = on_new_line case.inner }
-
-  let field t field =
-    on_new_line (enclose (const_atom (Field.name field) *> space *> t))
-  ;;
-
-  let record ~create = return create ;;
-
-  let finish_record t = enclose t ;;
+  let case_on_new_line (case : 'a Case.t) = { case with inner = on_new_line case.inner }
+  let field t field = on_new_line (enclose (const_atom (Field.name field) *> space *> t))
+  let record ~create = return create
+  let finish_record t = enclose t
 
   let nonempty_string ?placeholder ?width () =
     validate ~where:`After (string ?placeholder ?width ()) ~f:(fun s ->
       if String.is_empty s
-      then (Or_error.error_string "This field should not be empty.")
-      else (Ok ())
-    )
+      then Or_error.error_string "This field should not be empty."
+      else Ok ())
   ;;
 
   let positive_int =
     validate ~where:`After int ~f:(fun x ->
       if x <= 0
-      then (Or_error.error_string "This integer should be positive.")
-      else (Ok ())
-    )
+      then Or_error.error_string "This integer should be positive."
+      else Ok ())
   ;;
 
   let non_negative_int =
     validate ~where:`After int ~f:(fun x ->
       if x < 0
-      then (Or_error.error_string "This integer should not be negative.")
-      else (Ok ())
-    )
+      then Or_error.error_string "This integer should not be negative."
+      else Ok ())
   ;;
 
   let case_raw = Case.of_raw_parts
   let case = Case.of_variant
-  let (<|*>) = Case.apply
-  let (<.*>) = (<*>)
+  let ( <|*> ) = Case.apply
+  let ( <.*> ) = ( <*> )
 
   module Match = struct
     type t =
       { index : int
       ; left : Sexp.t list
       ; right : Sexp.t list
-      } [@@deriving fields]
+      }
+    [@@deriving fields]
   end
 
   let find_matching cases parse_state =
@@ -501,8 +445,8 @@ module Primitives = struct
     let cases_with_index = List.mapi cases ~f:Tuple2.create in
     let find_matching ~left ~right ~atom =
       let index =
-        List.find cases_with_index
-          ~f:(fun (_, case) -> String.equal (Case.name case) atom)
+        List.find cases_with_index ~f:(fun (_, case) ->
+          String.equal (Case.name case) atom)
       in
       match index with
       | None -> fail ()
@@ -511,55 +455,44 @@ module Primitives = struct
     Option.map (Parse_state.default parse_state) ~f:(function
       | Atom atom :: right -> find_matching ~left:[] ~right ~atom
       | List (Atom atom :: left) :: right -> find_matching ~left ~right ~atom
-      | _ -> fail ()
-    )
+      | _ -> fail ())
   ;;
 
   let variant ?don't_state_options_in_error cases =
     let maybe_enclose form =
       Interactive.map_nodes_value_dependent form ~f:(fun (_, enclose) nodes ->
         match enclose with
-        | `Enclose       -> [ Node.text "(" ] @ nodes @ [ Node.text ")" ]
-        | `Don't_enclose -> nodes
-      )
+        | `Enclose -> [ Node.text "(" ] @ nodes @ [ Node.text ")" ]
+        | `Don't_enclose -> nodes)
       |> Interactive.map ~f:fst
     in
     (fun parse_state ->
        let match_ = find_matching cases parse_state in
        let cases_as_editors =
          List.mapi cases ~f:(fun index case ->
-           let { Case. name; inner; has_been_applied } = case in
-           let form_and_enclose = lazy (
-             let parse_state =
-               match match_ with
-               | Some match_ ->
-                 if index = Match.index match_
-                 then (Parse_state.with_default parse_state (Match.left match_))
-                 else (Parse_state.erase_default parse_state)
-               | None -> parse_state
-             in
-             let parse_state =
-               if has_been_applied
-               then (Parse_state.indent parse_state)
-               else (parse_state)
-             in
-             let enclose =
-               if has_been_applied
-               then (`Enclose)
-               else (`Don't_enclose)
-             in
-             let inner =
-               if has_been_applied
-               then (space *> inner)
-               else (inner)
-             in
-             let { Init_result. parse_state; form } = inner parse_state in
-             let () = Parse_state.require_empty parse_state in
-             Ok (form, enclose)
-           )
+           let { Case.name; inner; has_been_applied } = case in
+           let form_and_enclose =
+             lazy
+               (let parse_state =
+                  match match_ with
+                  | Some match_ ->
+                    if index = Match.index match_
+                    then Parse_state.with_default parse_state (Match.left match_)
+                    else Parse_state.erase_default parse_state
+                  | None -> parse_state
+                in
+                let parse_state =
+                  if has_been_applied
+                  then Parse_state.indent parse_state
+                  else parse_state
+                in
+                let enclose = if has_been_applied then `Enclose else `Don't_enclose in
+                let inner = if has_been_applied then space *> inner else inner in
+                let { Init_result.parse_state; form } = inner parse_state in
+                let () = Parse_state.require_empty parse_state in
+                Ok (form, enclose))
            in
-           name, form_and_enclose
-         )
+           name, form_and_enclose)
        in
        let parse_state =
          match match_ with
@@ -586,18 +519,19 @@ module Primitives = struct
          match Lazy.force choice with
          | Error err -> return (Ok (Error err), `Don't_enclose)
          | Ok (form, enclose) ->
-           match%map form with
-           | Error err -> Error err, enclose
-           | Ok value -> Ok (Ok value), enclose
+           (match%map form with
+            | Error err -> Error err, enclose
+            | Ok value -> Ok (Ok value), enclose)
        in
        let form = maybe_enclose form in
-       Init_result.Fields.create ~parse_state ~form
-    )
+       Init_result.Fields.create ~parse_state ~form)
     |> handle_error ~where:`After
   ;;
 
   let enumeration ?don't_state_options_in_error elts ~to_string =
-    let cases = List.map elts ~f:(fun x -> case_raw ~name:(to_string x) ~constructor:x) in
+    let cases =
+      List.map elts ~f:(fun x -> case_raw ~name:(to_string x) ~constructor:x)
+    in
     variant ?don't_state_options_in_error cases
   ;;
 
@@ -608,15 +542,14 @@ module Primitives = struct
       -> ?max_size:int
       -> ?add_and_remove_button_attrs:Attr.t list
       -> ?editor_message_attr:Attr.t
-      -> order:[ `Ordered | `Unordered ]
+      -> order:[`Ordered | `Unordered]
       -> 'a t
       -> 'a list t
   end = struct
-
     let add_text ?element_name ~order =
       let order_text =
         match order with
-        | `Ordered -> ["here"]
+        | `Ordered -> [ "here" ]
         | `Unordered -> []
       in
       let element_text = Option.value_map element_name ~default:[] ~f:List.return in
@@ -636,7 +569,7 @@ module Primitives = struct
 
     module State = struct
       type 'a t =
-        { list_var           : 'a list Incr.Var.t
+        { list_var : 'a list Incr.Var.t
         ; deletion_stack_var : 'a list Incr.Var.t
         }
       [@@deriving fields]
@@ -648,18 +581,22 @@ module Primitives = struct
       ;;
 
       let default_modifying_button_attr =
-        [ Attr.style Css_gen.(
-            font_family ["Arial"]
-            @> font_size (`Pt 10.0)
-            @> uniform_padding (`Px 1)
-            @> margin_top (`Px 2)
-            @> margin_bottom (`Px 2)
-          )
+        [ Attr.style
+            Css_gen.(
+              font_family [ "Arial" ]
+              @> font_size (`Pt 10.0)
+              @> uniform_padding (`Px 1)
+              @> margin_top (`Px 2)
+              @> margin_bottom (`Px 2))
         ]
       ;;
 
-      let state_modifying_button ?(attrs=default_modifying_button_attr) state ~new_values
-            ~descr =
+      let state_modifying_button
+            ?(attrs = default_modifying_button_attr)
+            state
+            ~new_values
+            ~descr
+        =
         let open Interactive.Let_syntax in
         match%map_open button ~text:descr ~attrs () with
         | Not_pressed -> None
@@ -671,8 +608,15 @@ module Primitives = struct
       ;;
 
       let add_at_button
-            ?attrs state ~list ~deletion_stack
-            ~index ~add_text ~t ~init_blank =
+            ?attrs
+            state
+            ~list
+            ~deletion_stack
+            ~index
+            ~add_text
+            ~t
+            ~init_blank
+        =
         let new_values () =
           let new_form, new_deletion_stack =
             match deletion_stack with
@@ -698,139 +642,144 @@ module Primitives = struct
       ;;
 
       let values state =
-        Incr.Var.watch state.list_var,
-        Incr.Var.watch state.deletion_stack_var
+        Incr.Var.watch state.list_var, Incr.Var.watch state.deletion_stack_var
       ;;
-
     end
 
     let list
-          ?element_name ?gated_deletion ?max_size
+          ?element_name
+          ?gated_deletion
+          ?max_size
           ?add_and_remove_button_attrs
-          ?(editor_message_attr=default_editor_message_attr)
-          ~order t =
+          ?(editor_message_attr = default_editor_message_attr)
+          ~order
+          t
+      =
       let add_text = add_text ?element_name ~order in
       let remove_text = remove_text element_name in
       let allow_deletion_text = allow_deletion_text element_name in
       let open Interactive.Let_syntax in
-      enclose (
-        fun parse_state ->
-          let initial_list, parse_state =
-            match Parse_state.default parse_state with
-            | None -> [], parse_state
-            | Some sexps ->
-              let initial_list =
-                List.map sexps ~f:(fun x ->
-                  let parse_state = Parse_state.with_default parse_state [ x ] in
-                  let { Init_result. parse_state; form } = t parse_state in
-                  let () = Parse_state.require_empty parse_state in
-                  form
-                )
-              in
-              let parse_state = Parse_state.with_default parse_state [] in
-              initial_list, parse_state
+      enclose (fun parse_state ->
+        let initial_list, parse_state =
+          match Parse_state.default parse_state with
+          | None -> [], parse_state
+          | Some sexps ->
+            let initial_list =
+              List.map sexps ~f:(fun x ->
+                let parse_state = Parse_state.with_default parse_state [ x ] in
+                let { Init_result.parse_state; form } = t parse_state in
+                let () = Parse_state.require_empty parse_state in
+                form)
+            in
+            let parse_state = Parse_state.with_default parse_state [] in
+            initial_list, parse_state
+        in
+        let init_blank = Parse_state.erase_default parse_state in
+        let state = State.create ~initial_list in
+        let list, deletion_stack = State.values state in
+        let form =
+          let deletion_enabled_checkbox = Interactive.Primitives.checkbox () in
+          let%bind_open list = Interactive.of_incr list
+          and deletion_stack = Interactive.of_incr deletion_stack in
+          let adding_enabled =
+            match max_size with
+            | None -> true
+            | Some x -> List.length list < x
           in
-          let init_blank = Parse_state.erase_default parse_state in
-          let state = State.create ~initial_list in
-          let list, deletion_stack = State.values state in
-          let form =
-            let deletion_enabled_checkbox = Interactive.Primitives.checkbox () in
-            let%bind_open list = Interactive.of_incr list
-            and deletion_stack = Interactive.of_incr deletion_stack
-            in
-            let adding_enabled =
-              match max_size with
-              | None -> true
-              | Some x -> List.length list < x
-            in
-            let%bind_open deletion_enabled =
-              match gated_deletion with
-              | None -> return true
-              | Some () ->
-                if List.is_empty list
-                then (return false)
-                else (
-                  let%map_open deletion_enabled = deletion_enabled_checkbox
-                  and () =
-                    nodes
-                      [ Node.span
-                          [ editor_message_attr ]
-                          [ Node.text (" " ^ allow_deletion_text) ]
-                      ]
-                  in
-                  deletion_enabled
-                )
-            in
-            (* Each element in the list can have up to two buttons associated with it:
-               - an add button to add an element immediately before it
-               - a remove button to remove it
+          let%bind_open deletion_enabled =
+            match gated_deletion with
+            | None -> return true
+            | Some () ->
+              if List.is_empty list
+              then return false
+              else (
+                let%map_open deletion_enabled = deletion_enabled_checkbox
+                and () =
+                  nodes
+                    [ Node.span
+                        [ editor_message_attr ]
+                        [ Node.text (" " ^ allow_deletion_text) ]
+                    ]
+                in
+                deletion_enabled)
+          in
+          (* Each element in the list can have up to two buttons associated with it:
+             - an add button to add an element immediately before it
+             - a remove button to remove it
 
-               For each form in [list], the corresponding form in [forms_with_buttons]
-               contains the original form plus its associated add/remove buttons, and its
-               value consists of the original form's value along with any new list
-               produced by an associated button being pressed ([None] if no button was
-               pressed).
-            *)
-            let forms_with_buttons =
-              List.mapi list ~f:(fun index form ->
-                let button_with_new_list f ~sep =
-                  let%map_open new_list =
-                    f ?attrs:add_and_remove_button_attrs state ~list ~deletion_stack
-                      ~index
-                  and () = sep
-                  in
-                  new_list
-                in
-                let%map_open () = nodes (newline_nodes parse_state)
-                and add_button_new_list =
-                  match order, adding_enabled with
-                  | `Ordered, true ->
-                    button_with_new_list (State.add_at_button ~add_text ~t ~init_blank)
-                      ~sep:(nodes (newline_nodes parse_state))
-                  | `Unordered, _
-                  | _, false -> return None
-                and remove_button_new_list =
-                  if deletion_enabled
-                  then (
-                    button_with_new_list (State.remove_at_button ~remove_text)
-                      ~sep:(message " ")
-                  )
-                  else (return None)
-                and value = form
-                in
-                let new_list =
-                  Option.first_some add_button_new_list remove_button_new_list
-                in
-                value, new_list
-              )
-            in
-            let%bind_open forms_with_buttons = Interactive.all forms_with_buttons
-            and () =
-              if not (List.is_empty list) && adding_enabled
-              then (nodes (newline_nodes parse_state))
-              else (return ())
-            and last_add_button_new_list =
-              if adding_enabled
-              then (
-                State.add_at_button ?attrs:add_and_remove_button_attrs state ~list
-                  ~deletion_stack ~index:(List.length list) ~add_text ~t ~init_blank
-              )
-              else (return None)
-            in
-            let default, new_lists = List.unzip forms_with_buttons in
-            (* If there are multiple new lists (because multiple add/remove buttons were
-               pressed at roughly the same time), only the first new list is used and the
-               other button presses are ignored.
-            *)
-            let new_list =
-              List.find_map (last_add_button_new_list :: new_lists) ~f:Fn.id
-              |> Option.map ~f:Interactive.all
-            in
-            let%map value = Option.value new_list ~default:(return default) in
-            Or_error.all value
+             For each form in [list], the corresponding form in [forms_with_buttons]
+             contains the original form plus its associated add/remove buttons, and its
+             value consists of the original form's value along with any new list
+             produced by an associated button being pressed ([None] if no button was
+             pressed).
+          *)
+          let forms_with_buttons =
+            List.mapi list ~f:(fun index form ->
+              let button_with_new_list f ~sep =
+                let%map_open new_list =
+                  f
+                    ?attrs:add_and_remove_button_attrs
+                    state
+                    ~list
+                    ~deletion_stack
+                    ~index
+                and () = sep in
+                new_list
+              in
+              let%map_open () = nodes (newline_nodes parse_state)
+              and add_button_new_list =
+                match order, adding_enabled with
+                | `Ordered, true ->
+                  button_with_new_list
+                    (State.add_at_button ~add_text ~t ~init_blank)
+                    ~sep:(nodes (newline_nodes parse_state))
+                | `Unordered, _
+                | _, false -> return None
+              and remove_button_new_list =
+                if deletion_enabled
+                then
+                  button_with_new_list
+                    (State.remove_at_button ~remove_text)
+                    ~sep:(message " ")
+                else return None
+              and value = form in
+              let new_list =
+                Option.first_some add_button_new_list remove_button_new_list
+              in
+              value, new_list)
           in
-          Init_result.Fields.create ~form ~parse_state
-      )
+          let%bind_open forms_with_buttons = Interactive.all forms_with_buttons
+          and () =
+            if not (List.is_empty list) && adding_enabled
+            then nodes (newline_nodes parse_state)
+            else return ()
+          and last_add_button_new_list =
+            if adding_enabled
+            then
+              State.add_at_button
+                ?attrs:add_and_remove_button_attrs
+                state
+                ~list
+                ~deletion_stack
+                ~index:(List.length list)
+                ~add_text
+                ~t
+                ~init_blank
+            else return None
+          in
+          let default, new_lists = List.unzip forms_with_buttons in
+          (* If there are multiple new lists (because multiple add/remove buttons were
+             pressed at roughly the same time), only the first new list is used and the
+             other button presses are ignored.
+          *)
+          let new_list =
+            List.find_map (last_add_button_new_list :: new_lists) ~f:Fn.id
+            |> Option.map ~f:Interactive.all
+          in
+          let%map value = Option.value new_list ~default:(return default) in
+          Or_error.all value
+        in
+        Init_result.Fields.create ~form ~parse_state)
     ;;
   end
 
@@ -847,10 +796,9 @@ module Primitives = struct
       let parse_state =
         let open Sexp in
         Parse_state.map_default parse_state ~f:(function
-          | List [ Atom x; y ] :: z when String.equal x field_name ->
-            List [ Atom x; List [ y ] ] :: z
-          | sexps -> List [ Atom field_name; List [] ] :: sexps
-        )
+          | List [ Atom x; y ] :: z
+            when String.equal x field_name -> List [ Atom x; List [ y ] ] :: z
+          | sexps -> List [ Atom field_name; List [] ] :: sexps)
       in
       inner parse_state
   ;;
@@ -858,7 +806,7 @@ module Primitives = struct
   let bool ~true_ ~false_ =
     let inner =
       variant
-        [ case_raw ~name:true_  ~constructor:true
+        [ case_raw ~name:true_ ~constructor:true
         ; case_raw ~name:false_ ~constructor:false
         ]
     in
@@ -866,48 +814,43 @@ module Primitives = struct
       let parse_state =
         let open Sexp in
         Parse_state.map_default parse_state ~f:(function
-          | Atom "true"  :: x -> Atom true_  :: x
+          | Atom "true" :: x -> Atom true_ :: x
           | Atom "false" :: x -> Atom false_ :: x
-          | x -> x
-        )
+          | x -> x)
       in
       inner parse_state
   ;;
 
-  let bool_true_false = bool ~true_:"true" ~false_:"false" ;;
-  let bool_yes_no     = bool ~true_:"yes"  ~false_:"no"    ;;
-
-
-  let tuple2 a b =
-    return (fun a b -> a, b)
-    <*> a <* space
-    <*> b
-    |> enclose
-  ;;
+  let bool_true_false = bool ~true_:"true" ~false_:"false"
+  let bool_yes_no = bool ~true_:"yes" ~false_:"no"
+  let tuple2 a b = return (fun a b -> a, b) <*> a <* space <*> b |> enclose
 
   let tuple3 a b c =
-    return (fun a b c -> a, b, c)
-    <*> a <* space
-    <*> b <* space
-    <*> c
-    |> enclose
+    return (fun a b c -> a, b, c) <*> a <* space <*> b <* space <*> c |> enclose
   ;;
 
   let tuple4 a b c d =
     return (fun a b c d -> a, b, c, d)
-    <*> a <* space
-    <*> b <* space
-    <*> c <* space
+    <*> a
+    <* space
+    <*> b
+    <* space
+    <*> c
+    <* space
     <*> d
     |> enclose
   ;;
 
   let tuple5 a b c d e =
     return (fun a b c d e -> a, b, c, d, e)
-    <*> a <* space
-    <*> b <* space
-    <*> c <* space
-    <*> d <* space
+    <*> a
+    <* space
+    <*> b
+    <* space
+    <*> c
+    <* space
+    <*> d
+    <* space
     <*> e
     |> enclose
   ;;
@@ -921,8 +864,7 @@ module Primitives = struct
   ;;
 
   let set ?element_name ?gated_deletion ?max_size ~of_list t =
-    list ?element_name ?gated_deletion ?max_size ~order:`Unordered t
-    |> map ~f:of_list
+    list ?element_name ?gated_deletion ?max_size ~order:`Unordered t |> map ~f:of_list
   ;;
 
   let recursive x =
@@ -930,44 +872,39 @@ module Primitives = struct
     f
   ;;
 
-  let collapse_indicator = "(...)" ;;
+  let collapse_indicator = "(...)"
 
-  let collapse ?(editor_message_attr=default_editor_message_attr) t =
-    fun parse_state ->
-      let initially_checked = Parse_state.has_default parse_state in
-      let { Init_result. parse_state; form } = t parse_state in
-      let open Interactive.Let_syntax in
-      let form =
-        let%bind_open checked = checkbox ~init:initially_checked ()
-        and () = nodes [ Node.span [ editor_message_attr ] [ Node.text " Collapse " ] ]
-        in
-        let%map_open value =
-          if checked
-          then (
-            Interactive.map_nodes_value_dependent form ~f:(fun value _nodes ->
-              match value with
-              | Error _ ->
-                [ Node.span
-                    [ error_attr ]
-                    [ Node.text "There is an error in the collapsed form." ]
-                ]
-              | Ok _ -> []
-            )
-          )
-          else form
-        and () = message (if checked then (collapse_indicator) else (""))
-        in
-        value
-      in
-      Init_result.Fields.create ~parse_state ~form
+  let collapse ?(editor_message_attr = default_editor_message_attr) t parse_state =
+    let initially_checked = Parse_state.has_default parse_state in
+    let { Init_result.parse_state; form } = t parse_state in
+    let open Interactive.Let_syntax in
+    let form =
+      let%bind_open checked = checkbox ~init:initially_checked ()
+      and () = nodes [ Node.span [ editor_message_attr ] [ Node.text " Collapse " ] ] in
+      let%map_open value =
+        if checked
+        then
+          Interactive.map_nodes_value_dependent form ~f:(fun value _nodes ->
+            match value with
+            | Error _ ->
+              [ Node.span
+                  [ error_attr ]
+                  [ Node.text "There is an error in the collapsed form." ]
+              ]
+            | Ok _ -> [])
+        else form
+      and () = message (if checked then collapse_indicator else "") in
+      value
+    in
+    Init_result.Fields.create ~parse_state ~form
   ;;
 
   let defaulting_to ~default ~sexp_of_t t =
     let default_param = [ sexp_of_t default ] in
     fun parse_state ->
-      let { Parse_state. default; indentation } = parse_state in
+      let { Parse_state.default; indentation } = parse_state in
       let default = Some (Option.value default ~default:default_param) in
-      let parse_state = { Parse_state. default; indentation } in
+      let parse_state = { Parse_state.default; indentation } in
       t parse_state
   ;;
 
@@ -987,19 +924,20 @@ module Primitives = struct
           let open Sexp in
           match enumerated_match with
           | None -> List [ Atom other_string; sexp ]
-          | Some (name, _) -> Atom name
-        )
+          | Some (name, _) -> Atom name)
       in
       inner parse_state
   ;;
-
 end
+
 include Primitives
 
 module Unsafe = struct
   include T
+
   module Let_syntax = struct
     include T
+
     module Let_syntax = struct
       include T
       module Open_on_rhs = Primitives
@@ -1010,53 +948,44 @@ end
 let map_that_can_fail t ~a_to_b ~b_to_a ~sexp_of_a ~b_of_sexp =
   (fun parse_state ->
      let parse_state =
-       Parse_state.transform_first_sexp parse_state
-         ~f:(fun sexp -> sexp |> b_of_sexp |> b_to_a |> sexp_of_a)
+       Parse_state.transform_first_sexp parse_state ~f:(fun sexp ->
+         sexp |> b_of_sexp |> b_to_a |> sexp_of_a)
      in
-     let { Init_result. form; parse_state } = t parse_state in
+     let { Init_result.form; parse_state } = t parse_state in
      let form =
-       Interactive.map form
+       Interactive.map
+         form
          ~f:(Or_error.map ~f:(fun x -> Or_error.try_with (fun () -> a_to_b x)))
      in
-     { Init_result. form; parse_state }
-  )
+     { Init_result.form; parse_state })
   |> handle_error ~where:`Before
   |> handle_error ~where:`Before
 ;;
 
 let map t ~a_to_b ~b_to_a ~sexp_of_a ~b_of_sexp =
-  map_that_can_fail t ~a_to_b:(fun x -> Or_error.return (a_to_b x))
-    ~b_to_a ~sexp_of_a ~b_of_sexp
+  map_that_can_fail
+    t
+    ~a_to_b:(fun x -> Or_error.return (a_to_b x))
+    ~b_to_a
+    ~sexp_of_a
+    ~b_of_sexp
 ;;
 
-let test
-      ~form
-      ~value
-      ~sexp_of_t
-      ~equal
-      ~on_failure =
-  let init =
-    Init.with_default
-      ~sexp_of_t
-      ~default:value
-      ~diff:Init.no_diff
-      ()
-  in
+let test ~form ~value ~sexp_of_t ~equal ~on_failure =
+  let init = Init.with_default ~sexp_of_t ~default:value ~diff:Init.no_diff () in
   let parsed_value = to_interactive ~init form |> Interactive.current_value in
   let result =
     match parsed_value with
     | Error err -> Error (Error.to_string_hum err)
     | Ok parsed_value ->
-      if (equal value parsed_value)
-      then (Ok ())
+      if equal value parsed_value
+      then Ok ()
       else
-        (Error
-           (sprintf
-              !"%{Sexp#hum}\nwas parsed as\n%{Sexp#hum}"
-              (sexp_of_t value)
-              (sexp_of_t parsed_value)
-           )
-        )
+        Error
+          (sprintf
+             !"%{Sexp#hum}\nwas parsed as\n%{Sexp#hum}"
+             (sexp_of_t value)
+             (sexp_of_t parsed_value))
   in
   match result, on_failure with
   | Ok (), _ -> ()
@@ -1064,192 +993,175 @@ let test
   | Error msg, `Print -> print_endline msg
 ;;
 
-let test_list
-      ~form
-      ~values
-      ~sexp_of_t
-      ~equal
-      ~on_failure =
+let test_list ~form ~values ~sexp_of_t ~equal ~on_failure =
   List.iter values ~f:(fun value -> test ~form ~value ~sexp_of_t ~equal ~on_failure)
 ;;
 
-let test_sequence
-      ~form
-      ~values
-      ~sexp_of_t
-      ~equal
-      ~on_failure =
+let test_sequence ~form ~values ~sexp_of_t ~equal ~on_failure =
   Sequence.iter values ~f:(fun value -> test ~form ~value ~sexp_of_t ~equal ~on_failure)
 ;;
 
-let%test_module _ = (module struct
-  let test          = test          ~on_failure:`Print
-  let test_list     = test_list     ~on_failure:`Print
-  let test_sequence = test_sequence ~on_failure:`Print
+let%test_module _ =
+  (module struct
+    let test = test ~on_failure:`Print
+    let test_list = test_list ~on_failure:`Print
+    let test_sequence = test_sequence ~on_failure:`Print
 
-  module type M = sig
-    type t
+    module type M = sig
+      type t
 
-    val equal     : t -> t -> bool
-    val sexp_of_t : t -> Sexp.t
-    val quickcheck_generator       : t Quickcheck.Generator.t
-  end
+      val equal : t -> t -> bool
+      val sexp_of_t : t -> Sexp.t
+      val quickcheck_generator : t Quickcheck.Generator.t
+    end
 
-  let test_form_randomly (type a) (module M : M with type t = a) form =
-    let values = Sequence.take (Quickcheck.random_sequence M.quickcheck_generator) 100 in
-    test_sequence ~form ~values ~sexp_of_t:M.sexp_of_t ~equal:M.equal
-  ;;
+    let test_form_randomly (type a) (module M : M with type t = a) form =
+      let values =
+        Sequence.take (Quickcheck.random_sequence M.quickcheck_generator) 100
+      in
+      test_sequence ~form ~values ~sexp_of_t:M.sexp_of_t ~equal:M.equal
+    ;;
 
-  let%expect_test "the [string] primitive is correct" =
-    test_form_randomly (module String) (string ());
-    [%expect {| |}]
-  ;;
+    let%expect_test "the [string] primitive is correct" =
+      test_form_randomly (module String) (string ());
+      [%expect {| |}]
+    ;;
 
-  let%expect_test "the [int] primitive is correct" =
-    test_form_randomly (module Int) int;
-    [%expect {| |}]
-  ;;
+    let%expect_test "the [int] primitive is correct" =
+      test_form_randomly (module Int) int;
+      [%expect {| |}]
+    ;;
 
-  let%expect_test "the [from_ppx_sexp_raw] primitive is correct" =
-    let open Date in
-    test_form_randomly (module Date) (from_ppx_sexp_raw t_of_sexp);
-    [%expect {| |}];
+    let%expect_test "the [from_ppx_sexp_raw] primitive is correct" =
+      let open Date in
+      test_form_randomly (module Date) (from_ppx_sexp_raw t_of_sexp);
+      [%expect {| |}];
+      let open String in
+      test_form_randomly (module String) (from_ppx_sexp_raw t_of_sexp);
+      [%expect {| |}];
+      let open Sexp in
+      test_form_randomly (module Sexp) (from_ppx_sexp_raw t_of_sexp);
+      [%expect {| |}]
+    ;;
 
-    let open String in
-    test_form_randomly (module String) (from_ppx_sexp_raw t_of_sexp);
-    [%expect {| |}];
+    let%expect_test "the [from_ppx_sexp] primitive is correct" =
+      let open Date in
+      test_form_randomly (module Date) (from_ppx_sexp ~t_of_sexp ());
+      [%expect {| |}];
+      let open String in
+      let form = from_ppx_sexp ~t_of_sexp () in
+      test_form_randomly (module String) form;
+      test ~form ~value:"\\\\\\" ~sexp_of_t ~equal;
+      [%expect {| |}];
+      let open Sexp in
+      test_form_randomly (module Sexp) (from_ppx_sexp ~t_of_sexp ());
+      [%expect {| |}]
+    ;;
 
-    let open Sexp in
-    test_form_randomly (module Sexp) (from_ppx_sexp_raw t_of_sexp);
-    [%expect {| |}]
-  ;;
+    let%expect_test "the [bool] primitives are correct" =
+      test_form_randomly (module Bool) bool_true_false;
+      test_form_randomly (module Bool) bool_yes_no;
+      [%expect {| |}]
+    ;;
 
-  let%expect_test "the [from_ppx_sexp] primitive is correct" =
-    let open Date in
-    test_form_randomly (module Date) (from_ppx_sexp ~t_of_sexp ());
-    [%expect {| |}];
+    let%expect_test "the [tuple5] primitive is correct" =
+      let form = tuple5 int int (string ()) bool_true_false bool_yes_no in
+      let values = [ 1, 2, "foo", true, false; 12, 33, "bar", false, false ] in
+      test_list
+        ~form
+        ~values
+        ~sexp_of_t:[%sexp_of: int * int * string * bool * bool]
+        ~equal:[%compare.equal: int * int * string * bool * bool];
+      [%expect {| |}]
+    ;;
 
-    let open String in
-    let form = from_ppx_sexp ~t_of_sexp () in
-    test_form_randomly (module String) form;
-    test ~form ~value:"\\\\\\" ~sexp_of_t ~equal;
-    [%expect {| |}];
+    let%expect_test "the [option] primitive is correct" =
+      let form = option int in
+      let values = [ None; Some 0; Some 42 ] in
+      test_list
+        ~form
+        ~values
+        ~sexp_of_t:[%sexp_of: int option]
+        ~equal:[%compare.equal: int option];
+      [%expect {| |}]
+    ;;
 
-    let open Sexp in
-    test_form_randomly (module Sexp) (from_ppx_sexp ~t_of_sexp ());
-    [%expect {| |}]
-  ;;
+    let%expect_test "the [list] primitive is correct" =
+      List.iter [ `Ordered; `Unordered ] ~f:(fun order ->
+        let form = list ~order int in
+        let values = [ []; [ 1 ]; [ 23; 44 ] ] in
+        test_list
+          ~form
+          ~values
+          ~sexp_of_t:[%sexp_of: int list]
+          ~equal:[%compare.equal: int list]);
+      [%expect {| |}]
+    ;;
 
-  let%expect_test "the [bool] primitives are correct" =
-    test_form_randomly (module Bool) bool_true_false;
-    test_form_randomly (module Bool) bool_yes_no;
-    [%expect {| |}];
-  ;;
+    module Foo = struct
+      type t =
+        | A
+        | B of int
+        | C of int * t
+      [@@deriving variants, sexp_of, compare]
 
-  let%expect_test "the [tuple5] primitive is correct" =
-    let form = tuple5 int int (string ()) bool_true_false bool_yes_no in
-    let values =
-      [ 1,  2,  "foo", true,  false
-      ; 12, 33, "bar", false, false
-      ]
-    in
-    test_list ~form ~values
-      ~sexp_of_t:[%sexp_of: int * int * string * bool * bool]
-      ~equal:[%compare.equal: int * int * string * bool * bool];
-    [%expect {| |}]
-  ;;
+      let equal = [%compare.equal: t]
+    end
 
-  let%expect_test "the [option] primitive is correct" =
-    let form = option int in
-    let values = [ None; Some 0; Some 42 ] in
-    test_list ~form ~values
-      ~sexp_of_t:[%sexp_of: int option]
-      ~equal:[%compare.equal: int option];
-    [%expect {| |}]
-  ;;
+    let%expect_test "the [variant] primitive is correct" =
+      let open Foo in
+      let form =
+        recursive (fun form ->
+          variant
+            (Variants.fold
+               ~init:[]
+               ~a:(fun acc a -> case a :: acc)
+               ~b:(fun acc b -> (case b <|*> int) :: acc)
+               ~c:(fun acc c -> (case c <|*> int <|*> form) :: acc)))
+      in
+      let values = [ A; B 12; C (42, A); C (17, B (-44)); C (0, C (1, C (123, A))) ] in
+      test_list ~form ~values ~sexp_of_t ~equal;
+      [%expect {| |}]
+    ;;
 
-  let%expect_test "the [list] primitive is correct" =
-    List.iter [ `Ordered; `Unordered ] ~f:(fun order ->
-      let form = list ~order int in
-      let values = [ []; [ 1 ]; [ 23; 44 ] ] in
-      test_list ~form ~values
-        ~sexp_of_t:[%sexp_of: int list]
-        ~equal:[%compare.equal: int list]
-    );
-    [%expect {| |}]
-  ;;
+    module Bar = struct
+      type t =
+        { a : int
+        ; b : string sexp_option
+        ; c : t option
+        }
+      [@@deriving fields, sexp_of, compare]
 
-  module Foo = struct
-    type t =
-      | A
-      | B of int
-      | C of int * t
-    [@@deriving variants, sexp_of, compare]
+      let equal = [%compare.equal: t]
+    end
 
-    let equal = [%compare.equal: t]
-  end
+    let%expect_test "the [record] primitive is correct" =
+      let open Bar in
+      let form =
+        recursive (fun form ->
+          record ~create:(fun a b c -> Fields.create ~a ~b ~c)
+          <.*> field int Fields.a
+          <.*> sexp_option_field (string ()) Fields.b
+          <.*> field (option form) Fields.c
+          |> finish_record)
+      in
+      let values =
+        [ { a = 1; b = None; c = None }
+        ; { a = 1; b = Some "foo"; c = None }
+        ; { a = 4; b = None; c = Some { a = 12; b = Some "baz"; c = None } }
+        ]
+      in
+      test_list ~form ~values ~sexp_of_t ~equal;
+      [%expect {| |}]
+    ;;
 
-  let%expect_test "the [variant] primitive is correct" =
-    let open Foo in
-    let form =
-      recursive (fun form ->
-        variant
-          (Variants.fold
-             ~init:[]
-             ~a:(fun acc a ->  case a                     :: acc)
-             ~b:(fun acc b -> (case b <|*> int)           :: acc)
-             ~c:(fun acc c -> (case c <|*> int <|*> form) :: acc)
-          )
-      )
-    in
-    let values =
-      [ A
-      ; B 12
-      ; C (42, A)
-      ; C (17, B (-44))
-      ; C (0, C (1, C (123, A)))
-      ]
-    in
-    test_list ~form ~values ~sexp_of_t ~equal;
-    [%expect {| |}]
-  ;;
-
-  module Bar = struct
-    type t =
-      { a : int
-      ; b : string sexp_option
-      ; c : t option
-      }
-    [@@deriving fields, sexp_of, compare]
-
-    let equal = [%compare.equal: t]
-  end
-
-  let%expect_test "the [record] primitive is correct" =
-    let open Bar in
-    let form =
-      recursive (fun form ->
-        record ~create:(fun a b c -> Fields.create ~a ~b ~c)
-        <.*> field             int           Fields.a
-        <.*> sexp_option_field (string ())   Fields.b
-        <.*> field             (option form) Fields.c
-        |> finish_record)
-    in
-    let values =
-      [ { a = 1; b = None; c = None }
-      ; { a = 1; b = Some "foo"; c = None }
-      ; { a = 4; b = None; c = Some { a = 12; b = Some "baz"; c = None } }
-      ]
-    in
-    test_list ~form ~values ~sexp_of_t ~equal;
-    [%expect {| |}]
-  ;;
-
-  let%expect_test "the [dropdown_with_other] primitive is correct" =
-    let open Int in
-    let values = [ 1; 2; 3; 4; 1234 ] in
-    let form = dropdown_with_other ~other:int ~sexp_of_t [ "one", 1; "3", 2; "4", 2 ] in
-    test_list ~form ~values ~sexp_of_t ~equal;
-  ;;
-
-end)
+    let%expect_test "the [dropdown_with_other] primitive is correct" =
+      let open Int in
+      let values = [ 1; 2; 3; 4; 1234 ] in
+      let form =
+        dropdown_with_other ~other:int ~sexp_of_t [ "one", 1; "3", 2; "4", 2 ]
+      in
+      test_list ~form ~values ~sexp_of_t ~equal
+    ;;
+  end)
+;;

--- a/src/sexp_form.mli
+++ b/src/sexp_form.mli
@@ -48,10 +48,7 @@ module Init : sig
   val no_diff : original:Sexp.t -> updated:Sexp.t -> Incr_dom.Vdom.Node.t
 end
 
-val to_interactive
-  :  init:'a Init.t
-  -> 'a t
-  -> 'a Or_error.t Interactive.t
+val to_interactive : init:'a Init.t -> 'a t -> 'a Or_error.t Interactive.t
 
 (** A ['a Case.t] is implemented as a ['a Sexp_form.t].
     When you create a case from a variant constructor for variant [Foo.t],
@@ -85,19 +82,14 @@ module Record_field : sig
 end
 
 module Primitives : sig
-  val string          : ?placeholder:string -> ?width:int -> unit -> string t
+  val string : ?placeholder:string -> ?width:int -> unit -> string t
   val nonempty_string : ?placeholder:string -> ?width:int -> unit -> string t
-
-  val int              : int t
-  val positive_int     : int t
+  val int : int t
+  val positive_int : int t
   val non_negative_int : int t
-
-  val option
-    :  'a t
-    -> 'a option t
-
+  val option : 'a t -> 'a option t
   val bool_true_false : bool t
-  val bool_yes_no     : bool t
+  val bool_yes_no : bool t
 
   (** [element_name] is used for buttons. If you provide ~element_name:"foo", then the
       button will say "Add foo" instead of "Add".
@@ -118,7 +110,7 @@ module Primitives : sig
     -> ?max_size:int
     -> ?add_and_remove_button_attrs:Incr_dom.Vdom.Attr.t list
     -> ?editor_message_attr:Incr_dom.Vdom.Attr.t
-    -> order:[ `Ordered | `Unordered ]
+    -> order:[`Ordered | `Unordered]
     -> 'a t
     -> 'a list t
 
@@ -181,15 +173,10 @@ module Primitives : sig
           |> finish_record
       ]}
   *)
-  val record
-    :  create:('a -> 'b)
-    -> ('record, 'a -> 'b) Record_builder.t
+  val record : create:('a -> 'b) -> ('record, 'a -> 'b) Record_builder.t
 
   (** See documentation for [record]. *)
-  val field
-    :  'a t
-    -> ('record, 'a) Field.t
-    -> ('record, 'a) Record_field.t
+  val field : 'a t -> ('record, 'a) Field.t -> ('record, 'a) Record_field.t
 
   (** See documentation for [record]. *)
   val sexp_option_field
@@ -198,15 +185,13 @@ module Primitives : sig
     -> ('record, 'a sexp_option) Record_field.t
 
   (** See documentation for [record]. *)
-  val (<.*>)
+  val ( <.*> )
     :  ('record, 'a -> 'b) Record_builder.t
     -> ('record, 'a) Record_field.t
     -> ('record, 'b) Record_builder.t
 
   (** See documentation for [record]. *)
-  val finish_record
-    :  ('record, 'record) Record_builder.t
-    -> 'record t
+  val finish_record : ('record, 'record) Record_builder.t -> 'record t
 
   (** This has some special behaviour, namely that if the input string contains
       no parentheses or quotes then we will treat it as an atom -- so the user can enter
@@ -253,10 +238,7 @@ module Primitives : sig
       "Please select an option: Foo | Bar". If there are a lot of variants
       and you don't want this, you can use [don't_state_options_in_error].
   *)
-  val variant
-    :  ?don't_state_options_in_error:unit
-    -> 'a Case.t list
-    -> 'a t
+  val variant : ?don't_state_options_in_error:unit -> 'a Case.t list -> 'a t
 
   (** Mainly useful for polymorphic variants. For example, the following produces a
       [ `Foo of int ] Case.t:
@@ -265,21 +247,13 @@ module Primitives : sig
         case_raw ~name:"Foo" ~constructor:(fun x -> `Foo x) <|*> positive_int
       ]}
   *)
-  val case_raw
-    :  name:string
-    -> constructor:'a
-    -> 'a Case.t
+  val case_raw : name:string -> constructor:'a -> 'a Case.t
 
   (** See documentation for [variant]. *)
-  val case
-    :  'a Variantslib.Variant.t
-    -> 'a Case.t
+  val case : 'a Variantslib.Variant.t -> 'a Case.t
 
   (** See documentation for [variant]. *)
-  val (<|*>)
-    :  ('a -> 'b) Case.t
-    -> 'a t
-    -> 'b Case.t
+  val ( <|*> ) : ('a -> 'b) Case.t -> 'a t -> 'b Case.t
 
   (** Allows the user to choose from a list of ['a]s, which are displayed using
       the provided names in the dropdown, or enter their own choice by selecting
@@ -316,8 +290,9 @@ module Primitives : sig
   val enumeration
     :  ?don't_state_options_in_error:unit
     -> 'a list
-    -> to_string:('a -> string) (* You can use [ppx_variants] for this. *)
-    -> 'a t
+    -> to_string:('a -> string)
+    -> (* You can use [ppx_variants] for this. *)
+    'a t
 
   (** For recursive data types.
       Note: [recursive Fn.id] will go into an infinite loop when you call [to_interactive]
@@ -341,23 +316,18 @@ module Primitives : sig
                  ~cons:(fun acc const -> (case cons <|*> int <|*> my_list_editor) :: acc)))
       ]}
   *)
-  val recursive
-    :  ('a t -> 'a t)
-    -> 'a t
+  val recursive : ('a t -> 'a t) -> 'a t
 
   (** This is useful for e.g. specifying default values when the user creates a new
       element in a list. If you want a default value for the whole form, consider using
       [Init.with_default], which also shows the user a diff summarizing their
       edits.
   *)
-  val defaulting_to
-    :  default:'a
-    -> sexp_of_t:('a -> Sexp.t)
-    -> 'a t
-    -> 'a t
+  val defaulting_to : default:'a -> sexp_of_t:('a -> Sexp.t) -> 'a t -> 'a t
 
   (** These only affect formatting, not functionality. *)
   val on_new_line : 'a t -> 'a t
+
   val case_on_new_line : 'a Case.t -> 'a Case.t
 
   (** Hides the form by default, giving the user a checkbox to un-collapse the form if
@@ -365,12 +335,10 @@ module Primitives : sig
   val collapse : ?editor_message_attr:Incr_dom.Vdom.Attr.t -> 'a t -> 'a t
 
   val unit : unit t
-
   val tuple2 : 'a t -> 'b t -> ('a * 'b) t
   val tuple3 : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
   val tuple4 : 'a t -> 'b t -> 'c t -> 'd t -> ('a * 'b * 'c * 'd) t
   val tuple5 : 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> ('a * 'b * 'c * 'd * 'e) t
-
 end
 
 (** To map from ['a t] to ['b t], we need to be able to parse default values of type ['b].
@@ -410,10 +378,12 @@ module Unsafe : sig
 
   module Let_syntax : sig
     include Applicative.S with type 'a t := 'a t
+
     module Let_syntax : sig
       val return : 'a -> 'a t
       val map : 'a t -> f:('a -> 'b) -> 'b t
       val both : 'a t -> 'b t -> ('a * 'b) t
+
       module Open_on_rhs = Primitives
     end
   end
@@ -425,11 +395,7 @@ end
     It's recommended to use `After for errors which are right next to the area where
     the user inputs the data, and `Before for errors in complicated types which
     comprise many input fields. *)
-val validate
-  :  where:[ `Before | `After ]
-  -> 'a t
-  -> f:('a -> unit Or_error.t)
-  -> 'a t
+val validate : where:[`Before | `After] -> 'a t -> f:('a -> unit Or_error.t) -> 'a t
 
 (** Same as [validate], but more suited for validating properties which depend on
     external, changing state.
@@ -437,7 +403,7 @@ val validate
     Note that an [Incr] can be converted to an [Interactive] using [Interactive.of_incr].
 *)
 val validate_interactive
-  :  where:[ `Before | `After ]
+  :  where:[`Before | `After]
   -> 'a t
   -> 'b Interactive.t
   -> f:('a -> 'b -> unit Or_error.t)
@@ -448,10 +414,7 @@ val validate_interactive
 
     [validate] is a wrapper around [handle_error].
 *)
-val handle_error
-  :  where:[ `Before | `After ]
-  -> 'a Or_error.t t
-  -> 'a t
+val handle_error : where:[`Before | `After] -> 'a Or_error.t t -> 'a t
 
 (** Verifies that the provided [form] can parse [value].
     Intended for expect tests. *)
@@ -460,7 +423,7 @@ val test
   -> value:'a
   -> sexp_of_t:('a -> Sexp.t)
   -> equal:('a -> 'a -> bool)
-  -> on_failure:[ `Print | `Raise ]
+  -> on_failure:[`Print | `Raise]
   -> unit
 
 (** For convenience -- it just calls [test] for each value. *)
@@ -469,7 +432,7 @@ val test_list
   -> values:'a list
   -> sexp_of_t:('a -> Sexp.t)
   -> equal:('a -> 'a -> bool)
-  -> on_failure:[ `Print | `Raise ]
+  -> on_failure:[`Print | `Raise]
   -> unit
 
 (** For convenience -- it just calls [test] for each value. *)
@@ -478,5 +441,5 @@ val test_sequence
   -> values:'a Sequence.t
   -> sexp_of_t:('a -> Sexp.t)
   -> equal:('a -> 'a -> bool)
-  -> on_failure:[ `Print | `Raise ]
+  -> on_failure:[`Print | `Raise]
   -> unit

--- a/src/spinner.ml
+++ b/src/spinner.ml
@@ -1,0 +1,32 @@
+open! Core_kernel
+open Incr_dom.Vdom
+
+let circular =
+  Node.svg
+    "svg"
+    [ Attr.class_ "spinner" ]
+    [ Node.svg
+        "circle"
+        [ Attr.create "r" "30"; Attr.create "cx" "33"; Attr.create "cy" "33" ]
+        []
+    ]
+;;
+
+let logo =
+  Node.svg
+    "svg"
+    [ Attr.class_ "logo-spinner" ]
+    [ Node.svg
+        "circle"
+        [ Attr.create "r" "17"; Attr.create "cx" "33"; Attr.create "cy" "33" ]
+        []
+    ; Node.svg
+        "circle"
+        [ Attr.create "r" "23.5"; Attr.create "cx" "33"; Attr.create "cy" "33" ]
+        []
+    ; Node.svg
+        "circle"
+        [ Attr.create "r" "30"; Attr.create "cx" "33"; Attr.create "cy" "33" ]
+        []
+    ]
+;;

--- a/src/spinner.mli
+++ b/src/spinner.mli
@@ -1,0 +1,5 @@
+open! Core_kernel
+open Incr_dom.Vdom
+
+val circular : Node.t
+val logo : Node.t


### PR DESCRIPTION
Before:
  - It's not possible to connect form labels with form inputs by id.

Now:
  - `Form.Input.label` produces a label for a given id.